### PR TITLE
Changes to build_hit to run in the wrapper

### DIFF
--- a/src/reboost/build_hit.py
+++ b/src/reboost/build_hit.py
@@ -314,7 +314,7 @@ def build_hit(
                             "DETECTOR": out_detector,
                         }
                         # add fields
-                        for field, expression in proc_group["operations"].items():
+                        for field, expression in proc_group.get("operations", {}).items():
                             # evaluate the expression
                             col = core.evaluate_output_column(
                                 hit_table,
@@ -327,7 +327,10 @@ def build_hit(
                             hit_table.add_field(field, col)
 
                         # remove unwanted fields
-                        hit_table = core.remove_columns(hit_table, outputs=proc_group["outputs"])
+                        if "outputs" in proc_group:
+                            hit_table = core.remove_columns(
+                                hit_table, outputs=proc_group["outputs"]
+                            )
 
                         # get the IO mode
 


### PR DESCRIPTION
Some small changes:
- If no outputs field is supplied in the config then everything is saved
- The code should run without any processors.

If we want to go for a "global" trigger output further changes / a dedicated code is needed