### PR TITLE
Drift time calculation and grid generation

### DIFF
--- a/tests/hit/test_build_hit.py
+++ b/tests/hit/test_build_hit.py
@@ -112,7 +112,7 @@ def test_full_chain(tmptestdir):
         "truth_energy",
         "active_energy",
         "smeared_energy",
-        }
+    }
     assert set(hits["det002"].view_as("ak").fields) == {
         "evtid",
         "t0",

--- a/tests/hit/test_build_hit.py
+++ b/tests/hit/test_build_hit.py
@@ -106,17 +106,17 @@ def test_full_chain(tmptestdir):
 
     assert isinstance(hits, Struct)
 
-    assert hits["det001"].view_as("ak").fields == [
+    assert set(hits["det001"].view_as("ak").fields) == {
         "evtid",
         "t0",
         "truth_energy",
         "active_energy",
         "smeared_energy",
-    ]
-    assert hits["det002"].view_as("ak").fields == [
+        }
+    assert set(hits["det002"].view_as("ak").fields) == {
         "evtid",
         "t0",
         "truth_energy",
         "active_energy",
         "smeared_energy",
-    ]
+    }

--- a/tests/hpge/simulation/make_dt_map.jl
+++ b/tests/hpge/simulation/make_dt_map.jl
@@ -33,7 +33,7 @@ calculate_electric_potential!(
 )
 
 @info "Calculating electric field..."
-calculate_electric_field!(sim, n_points_in_φ=72)
+calculate_electric_field!(sim, n_points_in_φ=2)
 
 @info "Calculating weighting potential..."
 calculate_weighting_potential!(
@@ -46,8 +46,9 @@ calculate_weighting_potential!(
 
 function make_axis(T, boundary, gridsize)
     # define interior domain strictly within (0, boundary)
-    inner_start = 0 + 2*SSD.ConstructiveSolidGeometry.csg_default_tol(T)
-    inner_stop = boundary - 2*SSD.ConstructiveSolidGeometry.csg_default_tol(T)
+    offset = 2*SSD.ConstructiveSolidGeometry.csg_default_tol(T)
+    inner_start = 0 + offset
+    inner_stop = boundary - offset
 
     # compute number of intervals in the interior
     n = round(Int, (inner_stop - inner_start) / gridsize)
@@ -59,7 +60,7 @@ function make_axis(T, boundary, gridsize)
     axis = range(inner_start, step=step, length=n + 1)
 
     # prepend and append slightly out-of-bound points
-    extended_axis = [0 - 2*SSD.ConstructiveSolidGeometry.csg_default_tol(T), axis..., boundary + 2*SSD.ConstructiveSolidGeometry.csg_default_tol(T)]
+    extended_axis = [0 - offset, axis..., boundary + offset]
 
     return extended_axis
 end

--- a/tests/hpge/simulation/make_dt_map.jl
+++ b/tests/hpge/simulation/make_dt_map.jl
@@ -44,10 +44,10 @@ calculate_weighting_potential!(
     verbose=false
 )
 
-function make_axis(boundary, gridsize)
+function make_axis(T, boundary, gridsize)
     # define interior domain strictly within (0, boundary)
-    inner_start = 0 + eps()
-    inner_stop = boundary - eps()
+    inner_start = 0 + 2*SSD.ConstructiveSolidGeometry.csg_default_tol(T)
+    inner_stop = boundary - 2*SSD.ConstructiveSolidGeometry.csg_default_tol(T)
 
     # compute number of intervals in the interior
     n = round(Int, (inner_stop - inner_start) / gridsize)
@@ -59,7 +59,7 @@ function make_axis(boundary, gridsize)
     axis = range(inner_start, step=step, length=n + 1)
 
     # prepend and append slightly out-of-bound points
-    extended_axis = [0 - eps(), axis..., boundary + eps()]
+    extended_axis = [0 - 2*SSD.ConstructiveSolidGeometry.csg_default_tol(T), axis..., boundary + 2*SSD.ConstructiveSolidGeometry.csg_default_tol(T)]
 
     return extended_axis
 end
@@ -68,8 +68,8 @@ gridsize = 0.001 # in m
 radius = meta.geometry.radius_in_mm / 1000
 height = meta.geometry.height_in_mm / 1000
 
-x_axis = make_axis(radius, gridsize)
-z_axis = make_axis(height, gridsize)
+x_axis = make_axis(T, radius, gridsize)
+z_axis = make_axis(T, height, gridsize)
 
 spawn_positions = CartesianPoint{T}[]
 idx_spawn_positions = CartesianIndex[]
@@ -95,19 +95,16 @@ dt_threaded = Vector{Int}(undef, n)
 @threads for i in 1:n
     p = spawn_positions[in_idx[i]]
     e = SSD.Event([p], [2039u"keV"])
-    simulate!(e, sim, Δt = time_step, max_nsteps = max_nsteps, verbose = false)
+    drift_charges!(e, sim, Δt = time_step, max_nsteps = max_nsteps, verbose = false)
 
     # store results in preallocated arrays
-    wf = add_baseline_and_extend_tail(e.waveforms[1], 2000, 7000).signal
-    wfs_raw_threaded[i] = ustrip(wf)
-    dt_threaded[i] = length(e.waveforms[1].signal)
+    lhpath = length(e.drift_paths[1].h_path)
+    lepath = length(e.drift_paths[1].e_path)
+    dt_threaded[i] = max(lepath, lhpath)
 end
 
 # assign final results
-wfs_raw = wfs_raw_threaded
 dt = dt_threaded
-
-wfs = wfs_raw ./ maximum.(wfs_raw)
 
 drift_time = fill(NaN, length(x_axis), length(z_axis))
 for (i, idx) in enumerate(idx_spawn_positions[in_idx])

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -46,4 +46,4 @@ def test_cli(tmptestdir):
     )
 
     hit1 = lh5.read("hit/det001", f"{tmptestdir}/hit.lh5").view_as("ak")
-    assert hit1.fields == ["evtid", "t0", "truth_energy", "active_energy", "smeared_energy"]
+    assert set(hit1.fields) == {"evtid", "t0", "truth_energy", "active_energy", "smeared_energy"}


### PR DESCRIPTION
@tdixon97 found bulk points in the dt maps with obviously incorrect drift times. Looking closer these were exactly equal to `max_nsteps`. Therefore, the drift was not converging for these points in SSD. In https://github.com/legend-exp/legend-testdata/pull/35 I set `dl_thickness_in_mm = 1`. In this manner, `LegendDataManagement.jl` assigns this thickness to the n+ contact instead of the previously set value `0`. At the moment, in SSD, contacts without thickness can give rise to drift convergence issues in the bulk. 

Additionally, I realized that `eps()` is not a good starting value for the grid of the dt map. I changed this to `2*SSD.ConstructiveSolidGeometry.csg_default_tol(T)` to resolve edge effects. 

Finally, I sped up the dt map generation by around x10 by only drifting charges (`drift_charges!`) instead of drifting charges and generating waveforms (`simulate!`). Then dt is taken as the length of the electron and hole drift - whichever is longer - directly. 