### PR TITLE
Fix numpy copy deprecation warnings

### DIFF
--- a/src/reboost/hpge/psd.py
+++ b/src/reboost/hpge/psd.py
@@ -207,8 +207,8 @@ def _drift_time_heuristic_impl(
 
     # loop over hits
     for i in range(len(dt)):
-        t = np.asarray(dt[i])
-        e = np.asarray(edep[i])
+        t = ak.to_numpy(dt[i])
+        e = ak.to_numpy(edep[i])
 
         valid_idx = np.where(e > 0)[0]
         if len(valid_idx) < 2:

--- a/src/reboost/shape/group.py
+++ b/src/reboost/shape/group.py
@@ -121,8 +121,8 @@ def group_by_time(
     obj = _sort_data(obj, time_name=time_name, evtid_name=evtid_name)
 
     # get difference
-    time_diffs = np.diff(obj[time_name])
-    index_diffs = np.array(np.diff(obj[evtid_name]), dtype=np.int32)
+    time_diffs = np.diff(ak.to_numpy(obj[time_name]))
+    index_diffs = np.diff(ak.to_numpy(obj[evtid_name])).astype(np.int32)
 
     # index of the last element in each run
     time_change = (time_diffs > window * 1000) & (index_diffs == 0)


### PR DESCRIPTION
## Summary
- avoid calling numpy with `copy=False` for awkward arrays
- convert arrays via `ak.to_numpy` before running `np.diff` or `np.asarray`

## Testing
- `ruff check src tests`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numba')*

------
https://chatgpt.com/codex/tasks/task_e_68483141fde48330ad50578d42ebbc95