### PR TITLE
Fix minor documentation issues

### DIFF
--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -51,7 +51,7 @@ Package API reference <api/modules>
   Tools to handle creating simulated geometries in python.
 - [legend-pygeom-l200](https://github.com/legend-exp/legend-pygeom-l200):
   Implementation of the LEGEND-200 experiment,
-- [legend-pygeom-l1000](https://github.com/legend-exp/legend-pygeom-l200):
+- [legend-pygeom-l1000](https://github.com/legend-exp/legend-pygeom-l1000):
   Implementation of the LEGEND-1000 experiment,
 - [revertex](https://github.com/legend-exp/revertex/): Generation of vertices
   for simulations.

--- a/docs/source/manual/config.md
+++ b/docs/source/manual/config.md
@@ -31,11 +31,10 @@ example:
 
 ```yaml
 processing_groups:
-    - name: geds
-
+  - name: geds
     detector_mapping:
-        - output: det001
-        - output: det002
+      - output: det001
+      - output: det002
 ```
 
 Since if no "input" key is supplied to the dictionary it is assumed the input
@@ -49,11 +48,10 @@ table name. For example:
 
 ```yaml
 processing_groups:
-    - name: sipms
-
+  - name: sipms
     detector_mapping:
-        - output: det003
-          input: LAr
+      - output: det003
+        input: LAr
 ```
 
 Next for every detector we have the option to define (generically) a set of
@@ -89,11 +87,13 @@ outputs:
 ```
 
 :::{note}
+
 If the "outputs" key is not present all fields will be included!
+
 :::
 
 In case the flat output file option for _remage_ was used we need to
-define the the step grouping function (i.e. we create our hits). Here
+define the step grouping function (i.e. we create our hits). Here
 "STEPS" is a special keyword corresponding to the remage data.
 
 ```yaml

--- a/docs/source/manual/event.md
+++ b/docs/source/manual/event.md
@@ -29,8 +29,10 @@ or an older version of reboost is used this can be computed with
 {func}`pygama.evt.build_tcm`.
 
 :::{warning}
+
 In case a non-trivial table mapping is used in {func}`reboost.build_hit.build_hit`
 the TCM to describe the hit files may be different.
+
 :::
 
 ## Gathering data from other fields
@@ -47,7 +49,7 @@ written processors.
 One useful functionality is to select groups of channels. To do this the function
 {func}`reboost.shape.group.get_isin_group` can be used. This will return an awkward
 array with the same shape as the channels input of booleans indicating if a given
-channel was part of the group>
+channel was part of the group.
 
 # Full event tier post-processing
 

--- a/docs/source/manual/intro.md
+++ b/docs/source/manual/intro.md
@@ -7,15 +7,15 @@ _reboost_ contains both:
   configuration files,
 - a dedicated tool for computing and using scintillation optical maps.
 
-"{ref}`processors`" describes a _reboost_ processors and how to use these for a
+{ref}`processors` describes _reboost_ processors and how to use these for a
 simple simulation post-processing in a python script.
 
-Next "{ref}`config`" explains how to run the full "hit-tier" (more details
-later) post-processing with a configuration file, in a very simple way to data
+Next {ref}`config` explains how to run the full "hit-tier" (more details
+later) post-processing with a configuration file, in a way very similar to data
 processing with pygama. This provides a method to make a generic and customised
 simulation post-processing. This depends on generic and efficient iteration over
-the remage files described in "{ref}`iteration`". Finally, the information from
-multiple systems can be combined to build events (described in "{ref}`event`").
+the remage files described in {ref}`iteration`. Finally, the information from
+multiple systems can be combined to build events (described in {ref}`event`).
 
 ## Tiers in _reboost_
 
@@ -33,7 +33,7 @@ those in pygama:
   depend on only a single detector.
 - **tcm**: Or "time-coincidence-map" a mapping of which hits happened
   simultaneously (within the detector time resolution) between different
-  detector.
+  detectors.
 - **evt**: Or "event" the final output file combining the information from the
   various detectors/ subsystems.
 

--- a/docs/source/manual/iteration.md
+++ b/docs/source/manual/iteration.md
@@ -3,8 +3,10 @@
 # Efficient iteration over remage files
 
 :::{note}
+
 This step is only relevant for applications involving large simulation
 files, or where the reboost configuration file option is used.
+
 :::
 
 Simulation files are often very large. This poses a challenge in processing the
@@ -13,7 +15,7 @@ memory.
 
 In addition, not every simulated event will lead to energy deposits in the
 detectors, and each simulated event will have multiple rows in the output file
-(corresponding to the different) steps. This introduces a challenge in iterating
+(corresponding to the different steps). This introduces a challenge in iterating
 over the files, since a naive iteration could cause a simulated event to be
 split between two chunks.
 
@@ -32,7 +34,8 @@ The _geant4 event lookup map_ (or **glm**) is a solution to these issues. The
 
 - This object should be computed once per output table (detector).
 - Geant4 events that do not lead to rows in the output file are still included.
-  :::
+
+:::
 
 The **glm** can be build from the remage outputs using the
 {func}`reboost.build_glm.build_glm` function. A command line interface has also

--- a/docs/source/manual/optical.md
+++ b/docs/source/manual/optical.md
@@ -1,6 +1,6 @@
 (optics)=
 
-# Using optical map
+# Using optical maps
 
 :::{warning}
 
@@ -10,9 +10,9 @@ Work in progress, more will be added later!
 
 ## Creating optical maps
 
-### 1. Running remage simulations to get stp file
+### 1. Running remage simulations to get an stp file
 
-The map generation is performed directly with _remage_(_reboost_ is not involved
+The map generation is performed directly with _remage_ (_reboost_ is not involved
 in this step). An example macro to showcase the required settings (`map.mac`):
 
 ```
@@ -52,7 +52,7 @@ in this step). An example macro to showcase the required settings (`map.mac`):
 /gps/ene/mono     9.68 eV # 128nm (VUV) LAr scintillation
 /gps/ene/sigma    0.22 eV # gaussian width
 /gps/ang/type     iso
-# use random polariztation (this emits warnings that can be ignored)
+# use random polarization (this emits warnings that can be ignored)
 #/gps/polarization 1 1 1
 
 /run/beamOn 80000000
@@ -85,7 +85,7 @@ memory is available; the map object is _fully_ stored in memory. In this
 example: For the 58 hardware channels, the example above would require
 
 ```{math}
-\text{memory} = 8 \cdot n_x \cdot n_y \cdot n_z \cdot (n_\text{ch} + 4) = 8 \cdot 280 \cdot 280 \cdot 480 \cdot (58 + 4) = 19\times10^{9} \text{[bytes]}
+\text{memory} = 8 \cdot n_x \cdot n_y \cdot n_z \cdot (n_\text{ch} + 4) = 8 \cdot 280 \cdot 280 \cdot 480 \cdot (58 + 4) = 19 \times 10^{9} \, \text{bytes}
 ```
 
 but peak memory usage might be higher. The input buffer will also use some

--- a/docs/source/manual/processors.md
+++ b/docs/source/manual/processors.md
@@ -19,8 +19,10 @@ output into a jagged structure, where each row corresponds to a "hit" and the
 fields are variable length vectors containing information on the steps in each
 hit.
 :::{note}
+
 This is only relevant if the "flat" output structure of _remage_ files is
 used.
+
 :::
 
 Currently two step-grouping options are implemented. Once the remage output is
@@ -40,7 +42,7 @@ hits_by_time = group_by_time(data, window=10)  # unit is us
 
 ## Other processors
 
-Additional _reboost_ processors compute further quantities of interesting, this
+Additional _reboost_ processors compute further quantities of interest. This
 can consist of:
 
 - reduction (e.g. summing over steps),
@@ -48,13 +50,13 @@ can consist of:
   adding a dimension),
 - computing other quantities (eg. PSD heuristics etc.).
 
-The only prescriptiion for a _reboost_ processor is that the function should
+The only prescription for a _reboost_ processor is that the function should
 return either an {class}`lgdo.LGDO` object, or an {class}`awkward.Array`. These
 processors should not change the length of the object, i.e. they should only act
 on axes more than 1.
 
 The input parameters for processors should also be accepted as
-{class}`lgdo.LGDO` object, or an {class}`awkward.Array`
+{class}`lgdo.LGDO` objects, or as {class}`awkward.Array` instances.
 
 Documentation describing the various processors is contained in the API
 documentation. You can then import these functions and use them in your python

--- a/docs/source/tutorial/config.md
+++ b/docs/source/tutorial/config.md
@@ -16,7 +16,7 @@ The processing from a config file follows all the same steps as from the
 previous tutorial. However, it is generalised to allow larger scale processing.
 This tutorial describes only the `hit` tier processing (i.e. extraction of
 information relating to a single detector channel). Building "events", which
-combine information from multiple detectors, is handelled in the next tutorial.
+combine information from multiple detectors, is handled in the next tutorial.
 
 We will process the same data as last time, but for both germanium detectors
 and also the liquid argon table!
@@ -51,7 +51,7 @@ logger.setLevel(logging.INFO)
 We are now almost ready to start our post-processing. However, we need some
 configuration files to describe the post-processing we want to perform.
 
-In principle, only a single file is needed [[docs]](../manual/config.md). However,
+In principle, only a single file is needed [manual](../manual/config.md). However,
 the generalised approach of the _reboost_ processing means other files can be
 used, for example to supply parameters. There is also the possibility to supply
 some additional arguments, this is split from the main configuration file since
@@ -77,7 +77,7 @@ config:
       detector_objects: # define objects useful for post-processing
         name: pygeomtools.detectors.get_sensvol_by_uid(OBJECTS.geometry,int(DETECTOR[3:]))[0]
         meta: dbetto.AttrsDict(pygeomtools.get_sensvol_metadata(OBJECTS.geometry, DETECTOR_OBJECTS.name))
-        pyobj: legendhpges.make_hpge(pygeomtools.get_sensvol_metadata(OBJECTS.geometry,DETECTOR_OBJECTS.name), registry = None)
+        pyobj: legendhpges.make_hpge(pygeomtools.get_sensvol_metadata(OBJECTS.geometry,DETECTOR_OBJECTS.name), registry=None)
         phyvol: OBJECTS.geometry.physicalVolumeDict[DETECTOR_OBJECTS.name]
         det_pars: OBJECTS.user_pars[DETECTOR]
       outputs:
@@ -104,7 +104,7 @@ config:
         - t0
         - first_evtid
         - energy
-      hit_table_layout: reboost.shape.group.group_by_time(STEPS, window = 10)
+      hit_table_layout: reboost.shape.group.group_by_time(STEPS, window=10)
       operations:
         t0: ak.fill_none(ak.firsts(HITS.time, axis=-1), np.nan)
         first_evtid: ak.fill_none(ak.firsts(HITS.evtid, axis=-1), np.nan)
@@ -138,7 +138,8 @@ We should also create these parameters.
   characterisation, data production etc.
 - This syntax is fully generic, allowing to pass any arguments (eg. path to
   `LegendMetadata` etc.)
-  :::
+
+:::
 
 ```{code-block} yaml
 :caption: pars.yaml
@@ -160,8 +161,10 @@ The first section of our config involves the extraction of "global objects".
 These are any python objects useful for the full post-processing chain.
 
 :::{note}
+
 This step is fully general, the user is free to extract any object useful for
 their post-processing.
+
 :::
 
 ```yaml
@@ -186,7 +189,7 @@ SiPM detectors, or to HPGe detectors of different types. Our config
 specifies a list of processing groups, which should each have a name:
 
 ```yaml
-processing_groups
+processing_groups:
   - name: geds
 ```
 
@@ -234,7 +237,7 @@ Other options:
 
 ### Detector objects
 
-Similar to the "global objects" defined earlier it is often useless to have
+Similar to the "global objects" defined earlier it is often useful to have
 some objects related to one particular detector. This functionality could be
 useful to extract:
 
@@ -249,12 +252,12 @@ python expressions to evaluate. For example:
 detector_objects:
   name: pygeomtools.detectors.get_sensvol_by_uid(OBJECTS.geometry,int(DETECTOR[3:]))[0]
   meta: dbetto.AttrsDict(pygeomtools.get_sensvol_metadata(OBJECTS.geometry, DETECTOR_OBJECTS.name))
-  pyobj: legendhpges.make_hpge(pygeomtools.get_sensvol_metadata(OBJECTS.geometry,DETECTOR_OBJECTS.name), registry = None)
+  pyobj: legendhpges.make_hpge(pygeomtools.get_sensvol_metadata(OBJECTS.geometry,DETECTOR_OBJECTS.name), registry=None)
   phyvol: OBJECTS.geometry.physicalVolumeDict[DETECTOR_OBJECTS.name]
   det_pars: OBJECTS.user_pars[DETECTOR]
 ```
 
-again _reboost_ will take care of importing the neccesnecessaryary packages and
+Again _reboost_ will take care of importing the necessary packages and
 evaluating the expressions. These can depend on several special keywords:
 
 - `OBJECTS`: the global objects defined earlier.
@@ -275,8 +278,8 @@ and tools.
 
 ### Output fields
 
-We then can specify a list of fields we want in our output file. _reboost_ will
-take care of removing un-needed fields (eg. from intermediate steps in the
+We can then specify a list of fields we want in our output file. _reboost_ will
+take care of removing unneeded fields (eg. from intermediate steps in the
 calculations), from the output files.
 
 ```yaml
@@ -289,27 +292,31 @@ outputs:
   - r90
 ```
 
-::{note}
+:::{note}
+
 If the "outputs" key is not present all fields will be saved!
+
 :::
 
 ### Hit-table layout
 
 :::{note}
+
 For the default _remage_ output the files are already reshaped and this
 is not necessary!
+
 :::
 
 If remage is run with the "flat output" option it is necessary to reshape
-the tables to oriented by the "hits" in the detector,
-to do this we perform a step called the "hit-table
+the tables so they are oriented by the "hits" in the detector.
+To do this we perform a step called the "hit-table
 layout". This name is chosen since this step defines the shape of the hit
 table, while all following processors act on this table without changing its
 shape.
 
-Again we have the possibility to evaluate an arbitrary Python expression
-performing this step, as mentioned in the previous tutorial currently two
-functions are implemented in _reboost_ ({mod}`.shape.group`). However, the
+Again we have the possibility to evaluate an arbitrary Python expression to
+perform this step. As mentioned in the previous tutorial, currently two
+functions are implemented in _reboost_ ({mod}`reboost.shape.group`). However, the
 user is free to implement their own function, or use something else!
 
 The config block just provides the expression to evaluate:
@@ -322,8 +329,8 @@ here `STEPS` is an alias for the input stp table from _remage_.
 
 ### Processors
 
-Now finally we get to the interesting part of the processing chain! Computing
-post-processed quantities.. This is handled by the block called "operations".
+Now we finally get to the interesting part of the processing chain! Computing
+post-processed quantities. This is handled by the block called "operations".
 Our example is below:
 
 ```yaml
@@ -335,7 +342,7 @@ operations:
   activeness: reboost.math.functions.piecewise_linear_activeness(HITS.distance_to_nplus,fccd=DETECTOR_OBJECTS.det_pars.fccd_in_mm, dlf=DETECTOR_OBJECTS.det_pars.dlf)
   active_energy: ak.sum(HITS.edep*HITS.activeness, axis=-1)
   smeared_energy: reboost.math.stats.gaussian_sample(HITS.active_energy,DETECTOR_OBJECTS.det_pars.reso_fwhm_in_keV/2.355)
-  r90: reboost.hpge.psd.r90(HITS.edep,hits.xloc*1000,HITS.yloc*1000,HITS.zloc*1000)
+  r90: reboost.hpge.psd.r90(HITS.edep,HITS.xloc*1000,HITS.yloc*1000,HITS.zloc*1000)
 ```
 
 Each key gives a field to compute and a Python expression to evaluate. These
@@ -357,7 +364,7 @@ in the processing chain. Our example:
 - smears this with a Gaussian energy resolution,
 - computes the `r90` PSD heuristic.
 
-In our config file, these blocks are repeated for the LAr table, you will see the steps repeated.
+In our config file these blocks are repeated for the LAr table, so you will see the same steps again.
 
 ## Running the post-processing
 
@@ -430,7 +437,7 @@ lh5.show("hit_out.lh5")
 ```
 
 You can read this data with LGDO and then try making the plots from the
-previous section (or others). As an example lets try comparing the energy
+previous section (or others). As an example let's try comparing the energy
 spectra for the two detectors.
 
 ```python

--- a/docs/source/tutorial/simple.md
+++ b/docs/source/tutorial/simple.md
@@ -4,8 +4,8 @@ Simple post-processing of _remage_ simulations can be done in a python script
 or notebook. This has some limitations but is very useful for simple tasks.
 For more complicated tasks we have created a config file interface (see the
 next tutorial). This tutorial builds on the [_remage_
-tutorial](https://remage.readthedocs.io/en/stable/tutorial.html)) of two
-Germanium detectors in a LAr orb with a source. It describes how to run
+tutorial](https://remage.readthedocs.io/en/stable/tutorial.html) of two
+germanium detectors in a liquid-argon (LAr) orb with a source. It describes how to run
 a simple post-processing with reboost tools, and explains the usual steps.
 
 For this example we simulate $^{228}$Th in the source. We use the following
@@ -35,7 +35,7 @@ macro file (saved as `th228.mac`):
 ```
 
 And run the _remage_ (from inside the remage container / after installation
-[[instructions]](https://remage.readthedocs.io/en/stable/manual/install.html))
+[instructions](https://remage.readthedocs.io/en/stable/manual/install.html)
 simulation with:
 
 ```console
@@ -84,11 +84,13 @@ using the [legend-pygeom-tools](https://legend-pygeom-tools.readthedocs.io) pack
 This metadata can be used to create a python object describing the HPGe
 detectors using the
 [legend-pygeom-hpges](https://legend-pygeom-hpges.readthedocs.io) package.
-Among other things them HPGe object from this package has methods to compute
+Among other things, the HPGe object from this package has methods to compute
 detector properties (mass, surface area etc.) and to compute the distance of
 points from the detector surface.
 
-In this example we extract the _pyg4ometry.geant4.Registry_ object describing the geometry (see [[docs]](https://pyg4ometry.readthedocs.io/en/stable/autoapi/pyg4ometry/geant4/Registry/index.html#pyg4ometry.geant4.Registry.Registry), the _legend-pygeom-hpges_ HPGe python object [[docs]](https://legend-pygeom-hpges.readthedocs.io/en/stable/api/legendhpges.html#legendhpges.base.HPGe) and finally we extract the position of the BEGe detector (which we focus on for this analysis).
+In this example we extract the _pyg4ometry.geant4.Registry_ object describing the geometry (see the [pyg4ometry documentation](https://pyg4ometry.readthedocs.io/en/stable/autoapi/pyg4ometry/geant4/Registry/index.html#pyg4ometry.geant4.Registry.Registry)),
+the _legend-pygeom-hpges_ HPGe python object (see the [legend-pygeom-hpges documentation](https://legend-pygeom-hpges.readthedocs.io/en/stable/api/legendhpges.html#legendhpges.base.HPGe)),
+and finally we extract the position of the BEGe detector (which we focus on for this analysis).
 
 ```python
 reg = pyg4ometry.gdml.Reader("geometry.gdml").getRegistry()
@@ -99,15 +101,17 @@ position = reg.physicalVolumeDict["BEGe"].position.eval()
 ## Read the data
 
 Next we can read the data using the
-[[lgdo]](https://legend-pydataobj.readthedocs.io/en/stable/) package.
+[lgdo](https://legend-pydataobj.readthedocs.io/en/stable/) package.
 
 :::{warning}
+
 If the simulations files are large this approach can cause memory issues, in
 that case it is possible to iterate over the files instead using the
 GLMIterator (see the next tutorial).
+
 :::
 
-We use the [[awkward]](https://awkward-array.org/doc/main/) package to view the
+We use the [awkward](https://awkward-array.org/doc/main/) package to view the
 data, ideal for working with data with a "jagged" structure, i.e. many vectors
 of different lengths.
 
@@ -118,7 +122,9 @@ stp = lh5.read_as("stp/det001", "stp_out.lh5", "ak")
 ## Processors
 
 :::{note}
+
 If the _remage_ flat output file is used an additional step of "step-grouping" is required.
+
 :::
 Now we can compute some quantities based on our simulation. This is based on
 "processors" (see the User manual for more details). This is just any
@@ -129,7 +135,7 @@ The only requirements are:
 
 - the function should return an `LGDO.VectorOfVectors`, `LGDO.Array` or
   `LGDO.ArrayOfEqualSizedArrays`
-  [[docs]](https://legend-pydataobj.readthedocs.io/en/latest/api/lgdo.types.html)
+  [documentation](https://legend-pydataobj.readthedocs.io/en/latest/api/lgdo.types.html)
   object, or something able to be converted to this (awkward arrays for example),
 - the returned object should have the same length as the original stp table,
   i.e. the processors act on every row but they cannot add, remove or merge
@@ -148,7 +154,7 @@ thickness of inactive (commonly called "dead" layer).
 
 _reboost_ contains a function to compute the distance of points to the surface
 of the HPGe detector
-[[docs]](https://reboost.readthedocs.io/en/stable/api/reboost.hpge.html#reboost-hpge-surface-module).
+[documentation](https://reboost.readthedocs.io/en/stable/api/reboost.hpge.html#reboost-hpge-surface-module).
 
 ```python
 dist_all = reboost.hpge.surface.distance_to_surface(
@@ -285,7 +291,7 @@ energy (due to interactions in the dead-layer).
 
 The remage simulations do not include the effect of the energy resolution. To
 do this there is a reboost processor to sample from a Gaussian distribution
-[[docs]](https://reboost.readthedocs.io/en/stable/api/reboost.math.html#module-reboost.math.stats).
+[documentation](https://reboost.readthedocs.io/en/stable/api/reboost.math.html#module-reboost.math.stats).
 
 We demonstrate this with a sigma of 0.5 keV.
 


### PR DESCRIPTION
## Summary
- restore the blank line padding before and after admonition fences in the manual to preserve the intended formatting
- keep the extra spacing around tutorial admonitions so pre-commit does not collapse the colon fences

## Testing
- `pip install -e '.[all]'`
- `pre-commit run --files docs/source/manual/config.md docs/source/manual/event.md docs/source/manual/iteration.md docs/source/manual/processors.md docs/source/tutorial/config.md docs/source/tutorial/simple.md`
- `pytest` *(fails: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68cc0096ff748330967392087ef50652