### PR TITLE
Add tests to the exlint model

### DIFF
--- a/src/reboost/math/functions.py
+++ b/src/reboost/math/functions.py
@@ -75,9 +75,7 @@ def piecewise_linear_activeness(distances: ak.Array, fccd_in_mm: float, dlf: flo
     # reshape
     results = ak.unflatten(ak.Array(results), lengths) if distances_ak.ndim > 1 else results
 
-    results = ak.Array(results)
-
-    return units.attach_units(results, "mm")
+    return ak.Array(results)
 
 
 def vectorised_active_energy(

--- a/src/reboost/units.py
+++ b/src/reboost/units.py
@@ -4,9 +4,11 @@ import logging
 from typing import Any
 
 import awkward as ak
+import numpy as np
 import pint
 import pyg4ometry as pg4
-from lgdo import LGDO, VectorOfVectors
+from lgdo import LGDO
+from lgdo.types import VectorOfVectors
 from numpy.typing import ArrayLike
 
 log = logging.getLogger(__name__)
@@ -113,9 +115,12 @@ def units_conv_ak(
     # return ak.Array
     if isinstance(data, LGDO):
         return data.view_as("ak")
-    if isinstance(data, ak.Array):
-        return data
-    return ak.Array(data)
+
+    if isinstance(data, np.ndarray):
+        return ak.Array(data)
+    if data is not None:
+        return ak.Array(data)
+    return data
 
 
 def unwrap_lgdo(data: Any | LGDO | ak.Array, library: str = "ak") -> tuple[Any, pint.Unit | None]:

--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -31,6 +31,23 @@ def test_hpge_activeness():
     assert activeness[2][0] == 1
 
 
+def test_exlin():
+    # test first with beta = 0
+    activeness = functions.ex_lin_activeness([0.4, 1.0, 1.5], 1.0, 0.5, 0.0)
+    activeness_linear = functions.piecewise_linear_activeness(
+        [0.4, 1.0, 1.5], fccd_in_mm=1, dlf=0.5
+    )
+
+    assert ak.all(ak.isclose(activeness, activeness_linear))
+
+    # now test with beta > 0
+    activeness = functions.ex_lin_activeness([0.4, 0.6, 1.1], 1.0, 0.5, 0.05)
+
+    assert activeness[0] < 1.0
+    assert activeness[0] < activeness[1]
+    assert activeness[2] == 1.0
+
+
 def test_vectorised_activeness():
     # vary fccd
     distances = ak.Array([[0.2, 5], [0.6], [2], [5]])

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -37,7 +37,7 @@ def test_units_convfact():
 
 
 def test_units_conv_ak():
-    assert units.units_conv_ak([1], "m") == [1]
+    assert units.units_conv_ak([1], "m") == ak.Array([1])
 
     arr = Array([1, 2, 3], attrs={"units": "m"})
     assert ak.all(units.units_conv_ak(arr, "mm") == ak.Array([1000, 2000, 3000]))


### PR DESCRIPTION
This seems to work.. this is with fccd = 1.0 mm, alpha = 0.5 mm, beta = 0.05 mm, which should be a minor modification of the linear model with dlf = 0.5.
<img width="625" height="443" alt="image" src="https://github.com/user-attachments/assets/08567380-c38b-4bb1-ad09-e6710ca5ed9b" />

