### PR TITLE
add a method to extract directly the waveform from PSL

### DIFF
--- a/docs/source/manual/psd.md
+++ b/docs/source/manual/psd.md
@@ -104,6 +104,26 @@ waveforms = reboost.hpge.psd.waveform_from_pulse_shape_library(
 # now plot etc
 ```
 
+### Phi-angle dependence
+
+Pulse shape libraries can optionally include phi-dependent templates to account for azimuthal variations in detector response. When the pulse shape library contains phi-dependent waveforms (stored at different phi angles), you can provide the phi angle for each hit:
+
+```python
+# compute phi angle
+phi = np.arctan2(steps.yloc - y0, steps.xloc - x0) * 180 / np.pi
+
+# compute waveforms with phi-dependent templates
+waveforms = reboost.hpge.psd.waveform_from_pulse_shape_library(
+    steps.edep, r, (steps.zloc - z0), library, phi=phi
+)
+```
+
+The function automatically selects the closest template based on 45-degree repeating symmetry. This means that pulse shape libraries typically store templates at 0° and 45° angles, which are sufficient to cover the full 360° range due to the symmetry. For example:
+
+- Phi values in [0°, 22.5°) and [67.5°, 90°) use the 0° template
+- Phi values in [22.5°, 67.5°) use the 45° template
+- This pattern repeats every 90° around the detector
+
 :::{warning}
 
 This is many times slower than the {func}`reboost.hpge.psd.maximum_current` since the value of the waveform at every sample is calculated. The large size of the output waveforms means the function can also use a significant amount of memory.

--- a/docs/source/manual/psd.md
+++ b/docs/source/manual/psd.md
@@ -80,7 +80,7 @@ energy.
 
 :::{warning}
 
-The pulse shape library should consistient of waveforms aligned by t0 for waveform simulation.
+The pulse shape library should consist of waveforms aligned by t0 for waveform simulation.
 
 :::
 

--- a/docs/source/manual/psd.md
+++ b/docs/source/manual/psd.md
@@ -14,9 +14,13 @@ These simulation methods are experimental and should be employed at the users ow
 
 Charge drift software such as [SolidStateDetectors.jl](https://juliaphysics.github.io/SolidStateDetectors.jl/stable/),
 can be used to compute the "drift time", or the time for charges to drift until reaching the contact, for each point in the
-HPGe detector.
+HPGe detector. See [link](https://github.com/legend-exp/legend-simflow/blob/main/workflow/src/legendsimflow/scripts/make_hpge_drift_time_maps.jl) for example.
 
 _reboost_ defines a common input format for these mappings as described in {func}`reboost.hpge.utils.get_rz_field`.
+
+Alternatively for a more complete description of the PSD parameters a library of simulated waveforms can be used, again _reboost_
+defines a common input format (see {func}`reboost.hpge.utils.get_hpge_pulse_shape_library`).
+
 
 ## Drift time heuristic
 
@@ -24,12 +28,17 @@ From this the drift time for each interaction in the HPGe detector can be extrac
 
 ## A/E estimation
 
-Additionally _rebost_ contains experimental methods to estimate the A/E parameter used for PSD in point-contact HPGe detectors. This can either be based on a simple constant current waveform model (described in {func}`reboost.hpge.psd._current_pulse_model`). In this case the maximum current ("A" from A/E) can be estimated by {func}`reboost.hpge.psd.maximum_current`.
-The following lines of code allow to extract the drift time for each simulated hit, and estimate the A/E.
+Additionally _rebost_ contains experimental methods to estimate the A/E parameter used for PSD in point-contact HPGe detectors.
+
+These models are based on combining the "impulse response" (waveform) of each step in the Geant4 event with time-shifts given by the drift time maps. This can either be based on a simple constant current waveform model (described in {func}`reboost.hpge.psd._current_pulse_model`) or a library of simulated pulse shapes ({func}`reboost.hpge.utils.get_hpge_pulse_shape_library`).
+
+In both cases the maximum current ("A" from A/E) can be estimated by {func}`reboost.hpge.psd.maximum_current`.
+
+The following lines of code allow to extract the drift time for each simulated hit, and estimate the A/E (based on a single template).
 
 ```python
 # extract the necessary inputs
-template, times = reboost.hpge.psd.get_hpge_pulse_shape_library(...)
+template, times = reboost.hpge.psd.get_current_waveforms(...)
 drift_time_map = reboost.hpge.utils.get_rz_field(...)
 
 # extract drift time
@@ -43,7 +52,7 @@ a_max = reboost.hpge.psd.maximum_current(
 aoe = a_max / ak.sum(edep, axis=-1)
 ```
 
-Or instead a template per point of the HPGe detector can be employed, _reboost_ employs a similar input file format as described in {func}`reboost.hpge.utils.get_hpge_pulse_shape_library`. In this case this library can be passed to {func}`reboost.hpge.psd.maximum_current`.
+This function is highly optimised by only extracting the waveform value close to the maximum. This combined with the fact the computionally intensive charge drift simulation is done in advance means this is orders of magnitude faster than a full charge drift simulation.
 
 ## n+ surface effects
 
@@ -52,3 +61,39 @@ Finally, _reboost_ contains methods to account for the delayed charge collection
 The "surface response" of the detector, or the amount of charge arriving at the p-n junction as a function of time can be computed with {func}`reboost.hpge.surface.get_surface_response`. A matrix describing the response as a function of time and depth to the surface can be extracted with {func}`reboost.hpge.surface.get_surface_library`. The value in the final column of each row gives the charge collection efficiency (or "activeness").
 
 This can then also be used in the determination of A/E using {func}`reboost.hpge.psd.maximum_current`.
+
+:::{note}
+
+Currently n+ effects can only be included with the fixed template option of {func}`reboost.hpge.psd.maximum_current`.
+
+:::
+
+
+## Waveform simulation
+
+The library of simulated pulse shapes can also be used to extract a simulated waveform per event (see {func}`reboost.hpge.psd.waveform_pulse_shape_library`). This is simply performed by summing the waveforms in the pulse shape library weighted by their 
+energy.
+
+The following lines of code allow to extract a waveform per event:
+
+```python
+
+# create the library
+library = reboost.hpge.utils.get_hpge_pulse_shape_library(...)
+
+#read the remage file
+steps = lh5.read("stp",...).view_as("ak",with_units = True)
+
+# compute r, here x0, y0, z0 are the detector origin
+r = np.sqrt((steps.xloc-x0)**2+(steps.yloc-y0)**2)
+
+# now compute waveforms
+waveforms = reboost.hpge.psd.waveform_from_pulse_shape_library(steps.edep,r,(steps.zloc-z0),library)
+
+# now plot etc
+
+```
+:::{warning}
+
+This is many times slower than the {func}`reboost.hpge.psd.maximum_current` since the value of the waveform at every sample is calculated. The large size of the output waveforms means the function can also use a significant amount of memory.
+:::

--- a/docs/source/manual/psd.md
+++ b/docs/source/manual/psd.md
@@ -27,7 +27,7 @@ From this the drift time for each interaction in the HPGe detector can be extrac
 
 ## A/E estimation
 
-Additionally _rebost_ contains experimental methods to estimate the A/E parameter used for PSD in point-contact HPGe detectors.
+Additionally _reboost_ contains experimental methods to estimate the A/E parameter used for PSD in point-contact HPGe detectors.
 
 These models are based on combining the "impulse response" (waveform) of each step in the Geant4 event with time-shifts given by the drift time maps. This can either be based on a simple constant current waveform model (described in {func}`reboost.hpge.psd.get_current_template`) or a library of simulated pulse shapes ({func}`reboost.hpge.utils.get_hpge_pulse_shape_library`).
 

--- a/docs/source/manual/psd.md
+++ b/docs/source/manual/psd.md
@@ -16,7 +16,7 @@ Charge drift software such as [SolidStateDetectors.jl](https://juliaphysics.gith
 can be used to compute the "drift time", or the time for charges to drift until reaching the contact, for each point in the
 HPGe detector. See [link](https://github.com/legend-exp/legend-simflow/blob/main/workflow/src/legendsimflow/scripts/make_hpge_drift_time_maps.jl) for example.
 
-_reboost_ defines a common input format for these mappings as described in {func}`reboost.hpge.utils.get_rz_field`.
+_reboost_ defines a common input format for these mappings as described in {func}`reboost.hpge.utils.get_hpge_rz_field`.
 
 Alternatively for a more complete description of the PSD parameters a library of simulated waveforms can be used, again _reboost_
 defines a common input format (see {func}`reboost.hpge.utils.get_hpge_pulse_shape_library`).
@@ -29,7 +29,13 @@ From this the drift time for each interaction in the HPGe detector can be extrac
 
 Additionally _rebost_ contains experimental methods to estimate the A/E parameter used for PSD in point-contact HPGe detectors.
 
-These models are based on combining the "impulse response" (waveform) of each step in the Geant4 event with time-shifts given by the drift time maps. This can either be based on a simple constant current waveform model (described in {func}`reboost.hpge.psd._current_pulse_model`) or a library of simulated pulse shapes ({func}`reboost.hpge.utils.get_hpge_pulse_shape_library`).
+These models are based on combining the "impulse response" (waveform) of each step in the Geant4 event with time-shifts given by the drift time maps. This can either be based on a simple constant current waveform model (described in {func}`reboost.hpge.psd.get_current_template`) or a library of simulated pulse shapes ({func}`reboost.hpge.utils.get_hpge_pulse_shape_library`).
+
+:::{note}
+
+The pulse shape library should consist of current waveforms aligned by the time of their maximum for A/E estimation.
+
+:::
 
 In both cases the maximum current ("A" from A/E) can be estimated by {func}`reboost.hpge.psd.maximum_current`.
 
@@ -37,7 +43,7 @@ The following lines of code allow to extract the drift time for each simulated h
 
 ```python
 # extract the necessary inputs
-template, times = reboost.hpge.psd.get_current_waveforms(...)
+template, times = reboost.hpge.psd.get_current_template(...)
 drift_time_map = reboost.hpge.utils.get_rz_field(...)
 
 # extract drift time
@@ -69,8 +75,14 @@ Currently n+ effects can only be included with the fixed template option of {fun
 
 ## Waveform simulation
 
-The library of simulated pulse shapes can also be used to extract a simulated waveform per event (see {func}`reboost.hpge.psd.waveform_pulse_shape_library`). This is simply performed by summing the waveforms in the pulse shape library weighted by their
+The library of simulated pulse shapes can also be used to extract a simulated waveform per event (see {func}`reboost.hpge.psd.waveform_from_pulse_shape_library`). This is simply performed by summing the waveforms in the pulse shape library weighted by their
 energy.
+
+:::{warning}
+
+The pulse shape library should consistient of waveforms aligned by t0 for waveform simulation.
+
+:::
 
 The following lines of code allow to extract a waveform per event:
 

--- a/docs/source/manual/psd.md
+++ b/docs/source/manual/psd.md
@@ -21,7 +21,6 @@ _reboost_ defines a common input format for these mappings as described in {func
 Alternatively for a more complete description of the PSD parameters a library of simulated waveforms can be used, again _reboost_
 defines a common input format (see {func}`reboost.hpge.utils.get_hpge_pulse_shape_library`).
 
-
 ## Drift time heuristic
 
 From this the drift time for each interaction in the HPGe detector can be extracted with {func}`reboost.hpge.psd.drift_time`. Based on this it is possible to compute the "drift time heuristic" (see {func}`reboost.hpge.psd.drift_time_heuristic`). This is an arbitrary value describing the likelihood of an event to fail a PSD cut. When compared to calibration data this can be used to emulate the effect of PSD cuts.
@@ -68,31 +67,31 @@ Currently n+ effects can only be included with the fixed template option of {fun
 
 :::
 
-
 ## Waveform simulation
 
-The library of simulated pulse shapes can also be used to extract a simulated waveform per event (see {func}`reboost.hpge.psd.waveform_pulse_shape_library`). This is simply performed by summing the waveforms in the pulse shape library weighted by their 
+The library of simulated pulse shapes can also be used to extract a simulated waveform per event (see {func}`reboost.hpge.psd.waveform_pulse_shape_library`). This is simply performed by summing the waveforms in the pulse shape library weighted by their
 energy.
 
 The following lines of code allow to extract a waveform per event:
 
 ```python
-
 # create the library
 library = reboost.hpge.utils.get_hpge_pulse_shape_library(...)
 
-#read the remage file
-steps = lh5.read("stp",...).view_as("ak",with_units = True)
+# read the remage file
+steps = lh5.read("stp", ...).view_as("ak", with_units=True)
 
 # compute r, here x0, y0, z0 are the detector origin
-r = np.sqrt((steps.xloc-x0)**2+(steps.yloc-y0)**2)
+r = np.sqrt((steps.xloc - x0) ** 2 + (steps.yloc - y0) ** 2)
 
 # now compute waveforms
-waveforms = reboost.hpge.psd.waveform_from_pulse_shape_library(steps.edep,r,(steps.zloc-z0),library)
+waveforms = reboost.hpge.psd.waveform_from_pulse_shape_library(
+    steps.edep, r, (steps.zloc - z0), library
+)
 
 # now plot etc
-
 ```
+
 :::{warning}
 
 This is many times slower than the {func}`reboost.hpge.psd.maximum_current` since the value of the waveform at every sample is calculated. The large size of the output waveforms means the function can also use a significant amount of memory.

--- a/docs/source/manual/psd.md
+++ b/docs/source/manual/psd.md
@@ -57,7 +57,7 @@ a_max = reboost.hpge.psd.maximum_current(
 aoe = a_max / ak.sum(edep, axis=-1)
 ```
 
-This function is highly optimised by only extracting the waveform value close to the maximum. This combined with the fact the computionally intensive charge drift simulation is done in advance means this is orders of magnitude faster than a full charge drift simulation.
+This function is highly optimised by only extracting the waveform value close to the maximum. This combined with the fact the computationally intensive charge drift simulation is done in advance means this is orders of magnitude faster than a full charge drift simulation.
 
 ## n+ surface effects
 

--- a/docs/source/manual/psd.md
+++ b/docs/source/manual/psd.md
@@ -106,23 +106,7 @@ waveforms = reboost.hpge.psd.waveform_from_pulse_shape_library(
 
 ### Phi-angle dependence
 
-Pulse shape libraries can optionally include phi-dependent templates to account for azimuthal variations in detector response. When the pulse shape library contains phi-dependent waveforms (stored at different phi angles), you can provide the phi angle for each hit:
-
-```python
-# compute phi angle
-phi = np.arctan2(steps.yloc - y0, steps.xloc - x0) * 180 / np.pi
-
-# compute waveforms with phi-dependent templates
-waveforms = reboost.hpge.psd.waveform_from_pulse_shape_library(
-    steps.edep, r, (steps.zloc - z0), library, phi=phi
-)
-```
-
-The function automatically selects the closest template based on 45-degree repeating symmetry. This means that pulse shape libraries typically store templates at 0° and 45° angles, which are sufficient to cover the full 360° range due to the symmetry. For example:
-
-- Phi values in [0°, 22.5°) and [67.5°, 90°) use the 0° template
-- Phi values in [22.5°, 67.5°) use the 45° template
-- This pattern repeats every 90° around the detector
+Pulse shape libraries can optionally include phi-dependent templates to account for azimuthal variations in detector response. When the pulse shape library contains phi-dependent waveforms, you can provide the phi angle for each hit and the function will automatically select the closest template based on 45-degree repeating symmetry.
 
 :::{warning}
 

--- a/src/reboost/hpge/psd.py
+++ b/src/reboost/hpge/psd.py
@@ -592,7 +592,7 @@ def _get_phi_idx(phi: float, phi_grid: np.array) -> int:
     phi_in_quadrant = phi_normalized % 90.0
 
     # Find the closest angle in phi_grid, considering wrap-around
-    min_dist = 1e10
+    min_dist = np.inf
     best_idx = 0
     for i in range(len(phi_grid)):
         # Calculate angular distance considering periodicity
@@ -847,7 +847,7 @@ def _get_psl_waveforms_impl(
         zt = np.asarray(z[i])
         et = np.asarray(edep[i])
 
-        phi_t = np.asarray(phi[i]) if has_phi and phi is not None else None
+        phi_t = np.asarray(phi[i]) if phi is not None else None
 
         for j in range(len(et)):
             r_idx, z_idx = _get_template_idx(rt[j], zt[j], r_grid, z_grid)

--- a/src/reboost/hpge/psd.py
+++ b/src/reboost/hpge/psd.py
@@ -972,6 +972,13 @@ def waveform_from_pulse_shape_library(
         z coordinate for each step
     pulse_shape_library
         The pulse shape library to use, this should be an instance of :class:`HPGePulseShapeLibrary`.
+
+    Returns
+    -------
+    waveforms : awkward.Array
+        Awkward array of waveforms with shape ``(n_events, n_time_samples)``.
+        Each waveform has the same sampling and units as specified by the
+        pulse shape library.
     """
     # convert to target units
     edep = units.units_conv_ak(edep, "keV")

--- a/src/reboost/hpge/psd.py
+++ b/src/reboost/hpge/psd.py
@@ -893,6 +893,11 @@ def maximum_current(
     r = units.units_conv_ak(r, "mm")
     z = units.units_conv_ak(z, "mm")
 
+    for arr in [drift_time, dist_to_nplus, r, z]:
+        if arr is not None and not ak.all(ak.num(arr) == ak.num(edep)):
+            msg = "All input arrays should have the same number of steps."
+            raise ValueError(msg)
+
     # prepare inputs for surface sims
     include_surface_effects, dist_to_nplus, templates_surface, activeness_surface = (
         prepare_surface_inputs(dist_to_nplus, edep, templates_surface, activeness_surface, template)
@@ -973,6 +978,12 @@ def waveform_from_pulse_shape_library(
     r = units.units_conv_ak(r, pulse_shape_library.r_units)
     z = units.units_conv_ak(z, pulse_shape_library.z_units)
 
+    # validate inputs to prevent numba errors
+    for arr in [r, z]:
+        if not ak.all(ak.num(arr) == ak.num(edep)):
+            msg = "r, z and edep should have the same number of steps."
+            raise ValueError(msg)
+
     # prepare the library
     library = pulse_shape_library.waveforms
 
@@ -986,4 +997,4 @@ def waveform_from_pulse_shape_library(
         z_grid=pulse_shape_library.z,
     )
 
-    return ak.Array(waveforms)
+    return units.attach_units(ak.Array(waveforms), "keV")

--- a/src/reboost/hpge/psd.py
+++ b/src/reboost/hpge/psd.py
@@ -946,7 +946,7 @@ def waveform_from_pulse_shape_library(
     r"""Get the current waveform for each hit based on the pulse shape library.
 
     This is based on modelling the waveform as a sum over the pulse shape library templates:
-    
+
     .. math::
         A(t) = \sum_i E_i \times f(t, r_i, z_i)
 

--- a/src/reboost/hpge/psd.py
+++ b/src/reboost/hpge/psd.py
@@ -945,7 +945,8 @@ def waveform_from_pulse_shape_library(
 ) -> ak.Array:
     r"""Get the current waveform for each hit based on the pulse shape library.
 
-    This is based on modelling the waveform as a sum over the pulse shape library templates
+    This is based on modelling the waveform as a sum over the pulse shape library templates:
+    
     .. math::
         A(t) = \sum_i E_i \times f(t, r_i, z_i)
 

--- a/src/reboost/hpge/psd.py
+++ b/src/reboost/hpge/psd.py
@@ -852,8 +852,8 @@ def _get_psl_waveforms_impl(
         for j in range(len(et)):
             r_idx, z_idx = _get_template_idx(rt[j], zt[j], r_grid, z_grid)
 
-            if has_phi and phi_t is not None:
-                phi_idx = _get_phi_idx(phi_t[j], phi_grid)
+            if has_phi:
+                phi_idx = _get_phi_idx(phi_t[j], phi_grid) if phi_t is not None else 0
                 waveforms[i] += et[j] * pulse_shape_library[r_idx, z_idx, phi_idx]
             else:
                 waveforms[i] += et[j] * pulse_shape_library[r_idx, z_idx]
@@ -1100,4 +1100,4 @@ def waveform_from_pulse_shape_library(
         phi_grid=pulse_shape_library.phi,
     )
 
-    return units.attach_units(ak.Array(waveforms), "keV")
+    return ak.Array(waveforms)

--- a/src/reboost/hpge/psd.py
+++ b/src/reboost/hpge/psd.py
@@ -260,15 +260,7 @@ def _current_pulse_model(
 ) -> NDArray:
     r"""Analytic model for the current pulse in a Germanium detector.
 
-    Consists of a Gaussian, a high side exponential tail and a low side tail:
-
-    .. math::
-
-      \begin{align}
-      A(t) = \; &A_\text{max} \times (1-p-p_h) \times \text{Gauss}(t;\mu,\sigma) \\
-        &+ A \times p \; \left(1 - \text{erf}\left(\frac{t-\mu}{\sigma_i}\right)\right) \times \frac{e^{t/\tau}}{2e^{\mu/\tau}} \\
-        &+ A \times p_h \; \left(1 - \text{erf}\left(-\frac{t-\mu}{\sigma_i}\right)\right) \times \frac{1}{2}e^{-t/\tau}
-      \end{align}
+    Consists of a Gaussian, a high side exponential tail and a low side tail.
 
     Parameters
     ----------
@@ -856,6 +848,11 @@ def maximum_current(
 ) -> ak.Array:
     """Estimate the maximum current in the HPGe detector based on :func:`_estimate_current_impl`.
 
+    Warnings
+    --------
+    - If a pulse shape library is used it should consist of current waveforms normalised by their maximum.
+    - The templates will be shifted according to the drift time, thus it is important to ensure the waveforms are long enough (typically the time axis should extend beyond the range of drift times).
+
     Parameters
     ----------
     edep
@@ -956,6 +953,7 @@ def waveform_from_pulse_shape_library(
 
     Notes
     -----
+    - The pulse shape library should consist of waveforms aligned by t0.
     - This function is a slower way to get the psd parameters than :func:`maximum_current`, as it extracts the full waveform for each hit and then finds the maximum, rather than just finding the maximum directly.
     - The memory usage of this function can be high, as it extracts the full waveform for each hit.
 

--- a/src/reboost/hpge/utils.py
+++ b/src/reboost/hpge/utils.py
@@ -75,10 +75,9 @@ def get_hpge_pulse_shape_library(
         t0_u = "ns"
 
     dt = data["dt"].value
-
     dt_u = data["dt"].attrs["units"]
 
-    if t0_u != dt_u:
+    if (t0_u != dt_u) and (t0 != 0):
         msg = "t0 and dt must have the same units"
         raise ValueError(msg)
 

--- a/src/reboost/hpge/utils.py
+++ b/src/reboost/hpge/utils.py
@@ -93,7 +93,7 @@ def get_hpge_pulse_shape_library(
     # Check for phi-dependent fields (e.g., waveforms_000_deg, waveforms_045_deg)
     phi_fields = []
     phi_angles = []
-    for key in data.keys():
+    for key in data:
         if key.startswith(f"{field}_") and key.endswith("_deg"):
             # Extract phi angle from field name
             try:

--- a/src/reboost/hpge/utils.py
+++ b/src/reboost/hpge/utils.py
@@ -67,15 +67,23 @@ def get_hpge_pulse_shape_library(
         msg = f"{obj} in {filename} is not an LGDO Struct"
         raise ValueError(msg)
 
-    t0 = data["t0"].value
+    if "t0" in data:
+        t0 = data["t0"].value
+        t0_u = data["t0"].attrs["units"]
+    else:
+        t0 = 0
+        t0_u = "ns"
+
     dt = data["dt"].value
 
-    t0_u = data["t0"].attrs["units"]
     dt_u = data["dt"].attrs["units"]
 
     if t0_u != dt_u:
         msg = "t0 and dt must have the same units"
         raise ValueError(msg)
+
+    if "units" not in data[field].attrs:
+        data[field].attrs["units"] = ""
 
     tu = t0_u
 

--- a/src/reboost/hpge/utils.py
+++ b/src/reboost/hpge/utils.py
@@ -54,7 +54,7 @@ def get_hpge_pulse_shape_library(
     dimension representing the waveform. dt and t0 define the timestamps for the waveforms.
 
     For phi-dependent pulse shape libraries, multiple fields can be provided with suffixes
-    indicating the phi angle (e.g., ``waveforms_0deg``, ``waveforms_45deg``). These will be
+    indicating the phi angle (e.g., ``waveforms_000_deg``, ``waveforms_045_deg``). These will be
     automatically detected and stacked into a 4D array internally.
 
 
@@ -66,7 +66,7 @@ def get_hpge_pulse_shape_library(
         name of the HDF5 dataset where the data is saved.
     field
         name of the HDF5 dataset holding the waveforms. If phi-dependent fields exist,
-        they should be named as ``{field}_{phi}deg`` (e.g., ``waveforms_0deg``, ``waveforms_45deg``).
+        they should be named as ``{field}_{phi:03d}_deg`` (e.g., ``waveforms_000_deg``, ``waveforms_045_deg``).
     out_of_bounds_val
         value to use to replace NaNs in the field values.
     """
@@ -90,14 +90,14 @@ def get_hpge_pulse_shape_library(
         msg = "t0 and dt must have the same units"
         raise ValueError(msg)
 
-    # Check for phi-dependent fields (e.g., waveforms_0deg, waveforms_45deg)
+    # Check for phi-dependent fields (e.g., waveforms_000_deg, waveforms_045_deg)
     phi_fields = []
     phi_angles = []
     for key in data.keys():
-        if key.startswith(f"{field}_") and key.endswith("deg"):
+        if key.startswith(f"{field}_") and key.endswith("_deg"):
             # Extract phi angle from field name
             try:
-                phi_str = key[len(field) + 1 : -3]  # Remove prefix and "deg" suffix
+                phi_str = key[len(field) + 1 : -4]  # Remove prefix and "_deg" suffix
                 phi_val = float(phi_str)
                 phi_fields.append(key)
                 phi_angles.append(phi_val)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -112,13 +112,13 @@ def test_pulse_shape_library_with_phi(tmptestdir):
 
     # Create smaller arrays for testing
     r = z = np.linspace(0, 100, 20)
-    waveforms_0deg = np.zeros((20, 20, 100))
-    waveforms_45deg = np.zeros((20, 20, 100))
+    waveforms_000_deg = np.zeros((20, 20, 100))
+    waveforms_045_deg = np.zeros((20, 20, 100))
 
     for i in range(20):
         for j in range(20):
-            waveforms_0deg[i, j] = model[:100] * 1.0  # Use first 100 samples
-            waveforms_45deg[i, j] = model[:100] * 2.0  # Different values for testing
+            waveforms_000_deg[i, j] = model[:100] * 1.0  # Use first 100 samples
+            waveforms_045_deg[i, j] = model[:100] * 2.0  # Different values for testing
 
     t0 = -1000
     dt = 1
@@ -127,8 +127,8 @@ def test_pulse_shape_library_with_phi(tmptestdir):
         {
             "r": Array(r, attrs={"units": "mm"}),
             "z": Array(z, attrs={"units": "mm"}),
-            "waveforms_0deg": Array(waveforms_0deg, attrs={"units": ""}),
-            "waveforms_45deg": Array(waveforms_45deg, attrs={"units": ""}),
+            "waveforms_000_deg": Array(waveforms_000_deg, attrs={"units": ""}),
+            "waveforms_045_deg": Array(waveforms_045_deg, attrs={"units": ""}),
             "dt": Scalar(dt, attrs={"units": "ns"}),
             "t0": Scalar(t0, attrs={"units": "ns"}),
         }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -93,4 +93,49 @@ def test_pulse_shape_library(tmptestdir):
     return f"{tmptestdir}/pulse_shape_lib.lh5"
 
 
+@pytest.fixture(scope="module")
+def test_pulse_shape_library_with_phi(tmptestdir):
+    """Create a pulse shape library with phi-dependent fields."""
+    model, _ = psd.get_current_template(
+        -1000,
+        3000,
+        1.0,
+        amax=1,
+        mean_aoe=1,
+        mu=0,
+        sigma=100,
+        tau=100,
+        tail_fraction=0.65,
+        high_tail_fraction=0.1,
+        high_tau=10,
+    )
+
+    # Create smaller arrays for testing
+    r = z = np.linspace(0, 100, 20)
+    waveforms_0deg = np.zeros((20, 20, 100))
+    waveforms_45deg = np.zeros((20, 20, 100))
+
+    for i in range(20):
+        for j in range(20):
+            waveforms_0deg[i, j] = model[:100] * 1.0  # Use first 100 samples
+            waveforms_45deg[i, j] = model[:100] * 2.0  # Different values for testing
+
+    t0 = -1000
+    dt = 1
+
+    res = Struct(
+        {
+            "r": Array(r, attrs={"units": "mm"}),
+            "z": Array(z, attrs={"units": "mm"}),
+            "waveforms_0deg": Array(waveforms_0deg, attrs={"units": ""}),
+            "waveforms_45deg": Array(waveforms_45deg, attrs={"units": ""}),
+            "dt": Scalar(dt, attrs={"units": "ns"}),
+            "t0": Scalar(t0, attrs={"units": "ns"}),
+        }
+    )
+    lh5.write(res, "V01", f"{tmptestdir}/pulse_shape_lib_phi.lh5")
+
+    return f"{tmptestdir}/pulse_shape_lib_phi.lh5"
+
+
 patch_numba_for_tests()

--- a/tests/hpge/test_hpge_map.py
+++ b/tests/hpge/test_hpge_map.py
@@ -42,3 +42,22 @@ def test_read_pulse_shape_library(test_pulse_shape_library):
     assert isinstance(lib, HPGePulseShapeLibrary)
 
     assert np.shape(lib.waveforms) == (200, 200, 4001)
+
+
+def test_read_pulse_shape_library_with_phi(test_pulse_shape_library_with_phi):
+    """Test reading pulse shape library with phi-dependent fields."""
+    lib = get_hpge_pulse_shape_library(test_pulse_shape_library_with_phi, "V01", "waveforms")
+    assert isinstance(lib, HPGePulseShapeLibrary)
+
+    # Should have 4D array (r, z, phi, time)
+    assert np.shape(lib.waveforms) == (20, 20, 2, 100)
+
+    # Check phi angles are correctly extracted
+    assert lib.phi is not None
+    assert len(lib.phi) == 2
+    assert lib.phi[0] == 0.0
+    assert lib.phi[1] == 45.0
+
+    # Check that different phi have different values (should differ by factor of 2)
+    ratio = lib.waveforms[:, :, 1, :] / lib.waveforms[:, :, 0, :]
+    assert np.allclose(ratio, 2.0)

--- a/tests/hpge/test_waveforms.py
+++ b/tests/hpge/test_waveforms.py
@@ -13,7 +13,7 @@ def pulse_shape_library():
     waveforms = np.ones((40, 120, 100))
 
     return HPGePulseShapeLibrary(
-        waveforms, "mm","mm","ns", np.linspace(0, 20, 40), np.linspace(0, 60, 120), np.arange(100)
+        waveforms, "mm", "mm", "ns", np.linspace(0, 20, 40), np.linspace(0, 60, 120), np.arange(100)
     )
 
 
@@ -22,7 +22,7 @@ def test_get_waveforms(pulse_shape_library):
     z = units.attach_units(ak.Array([[50, 40], [10]]), "mm")
     edep = units.attach_units(ak.Array([[100, 200], [600]]), "keV")
 
-    waveforms = waveform_from_pulse_shape_library(edep, r, z,pulse_shape_library)
+    waveforms = waveform_from_pulse_shape_library(edep, r, z, pulse_shape_library)
 
     assert waveforms.to_numpy().shape == (2, 100)
     assert np.all(waveforms[0].to_numpy() == 300)

--- a/tests/hpge/test_waveforms.py
+++ b/tests/hpge/test_waveforms.py
@@ -17,6 +17,27 @@ def pulse_shape_library():
     )
 
 
+@pytest.fixture
+def pulse_shape_library_with_phi():
+    """Create a PSL with phi-dependent templates at 0 and 45 degrees."""
+    # Create waveforms with shape (r, z, phi, time)
+    # Use different values for 0 and 45 degrees to test selection
+    waveforms = np.zeros((40, 120, 2, 100))
+    waveforms[:, :, 0, :] = 1.0  # 0 degree templates
+    waveforms[:, :, 1, :] = 2.0  # 45 degree templates
+
+    return HPGePulseShapeLibrary(
+        waveforms,
+        "mm",
+        "mm",
+        "ns",
+        np.linspace(0, 20, 40),
+        np.linspace(0, 60, 120),
+        np.arange(100),
+        np.array([0.0, 45.0]),
+    )
+
+
 def test_get_waveforms(pulse_shape_library):
     r = units.attach_units(ak.Array([[10, 30], [20]]), "mm")
     z = units.attach_units(ak.Array([[50, 40], [10]]), "mm")
@@ -31,5 +52,56 @@ def test_get_waveforms(pulse_shape_library):
     waveforms = waveform_from_pulse_shape_library(
         ak.Array([[]]), ak.Array([[]]), ak.Array([[]]), pulse_shape_library
     )
+
+    assert waveforms.to_numpy().shape == (1, 100)
+    assert np.all(waveforms[0].to_numpy() == 0)
+
+
+def test_get_waveforms_with_phi(pulse_shape_library_with_phi):
+    """Test waveform extraction with phi-dependent templates."""
+    r = units.attach_units(ak.Array([[10, 30], [20]]), "mm")
+    z = units.attach_units(ak.Array([[50, 40], [10]]), "mm")
+    edep = units.attach_units(ak.Array([[100, 200], [600]]), "keV")
+
+    # Test phi = 0 degrees (should use 0-degree template with value 1.0)
+    phi = units.attach_units(ak.Array([[0, 0], [0]]), "deg")
+    waveforms = waveform_from_pulse_shape_library(edep, r, z, pulse_shape_library_with_phi, phi)
+
+    assert waveforms.to_numpy().shape == (2, 100)
+    assert np.all(waveforms[0].to_numpy() == 300)  # 100*1 + 200*1
+    assert np.all(waveforms[1].to_numpy() == 600)  # 600*1
+
+    # Test phi = 45 degrees (should use 45-degree template with value 2.0)
+    phi = units.attach_units(ak.Array([[45, 45], [45]]), "deg")
+    waveforms = waveform_from_pulse_shape_library(edep, r, z, pulse_shape_library_with_phi, phi)
+
+    assert waveforms.to_numpy().shape == (2, 100)
+    assert np.all(waveforms[0].to_numpy() == 600)  # 100*2 + 200*2
+    assert np.all(waveforms[1].to_numpy() == 1200)  # 600*2
+
+    # Test phi = 90 degrees (should use 0-degree template due to 45-deg symmetry)
+    phi = units.attach_units(ak.Array([[90, 90], [90]]), "deg")
+    waveforms = waveform_from_pulse_shape_library(edep, r, z, pulse_shape_library_with_phi, phi)
+
+    assert waveforms.to_numpy().shape == (2, 100)
+    assert np.all(waveforms[0].to_numpy() == 300)  # 100*1 + 200*1
+
+    # Test mixed phi values (10 deg -> 0 deg, 50 deg -> 45 deg)
+    phi = units.attach_units(ak.Array([[10, 50], [20]]), "deg")
+    waveforms = waveform_from_pulse_shape_library(edep, r, z, pulse_shape_library_with_phi, phi)
+
+    assert waveforms.to_numpy().shape == (2, 100)
+    assert np.all(waveforms[0].to_numpy() == 500)  # 100*1 + 200*2
+    assert np.all(waveforms[1].to_numpy() == 600)  # 600*1 (20 deg is closer to 0 than 45)
+
+
+def test_get_waveforms_without_phi_on_phi_library(pulse_shape_library_with_phi):
+    """Test that calling without phi on phi-enabled library works (uses first phi)."""
+    r = units.attach_units(ak.Array([[10, 30]]), "mm")
+    z = units.attach_units(ak.Array([[50, 40]]), "mm")
+    edep = units.attach_units(ak.Array([[100, 200]]), "keV")
+
+    # Should work but may use arbitrary phi value
+    waveforms = waveform_from_pulse_shape_library(edep, r, z, pulse_shape_library_with_phi)
 
     assert waveforms.to_numpy().shape == (1, 100)

--- a/tests/hpge/test_waveforms.py
+++ b/tests/hpge/test_waveforms.py
@@ -27,3 +27,9 @@ def test_get_waveforms(pulse_shape_library):
     assert waveforms.to_numpy().shape == (2, 100)
     assert np.all(waveforms[0].to_numpy() == 300)
     assert np.all(waveforms[1].to_numpy() == 600)
+
+    waveforms = waveform_from_pulse_shape_library(
+        ak.Array([[]]), ak.Array([[]]), ak.Array([[]]), pulse_shape_library
+    )
+
+    assert waveforms.to_numpy().shape == (1, 100)

--- a/tests/hpge/test_waveforms.py
+++ b/tests/hpge/test_waveforms.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import awkward as ak
+import numpy as np
+import pytest
+
+from reboost import units
+from reboost.hpge.psd import HPGePulseShapeLibrary, waveform_from_pulse_shape_library
+
+
+@pytest.fixture
+def pulse_shape_library():
+    waveforms = np.ones((40, 120, 100))
+
+    return HPGePulseShapeLibrary(
+        waveforms, "mm","mm","ns", np.linspace(0, 20, 40), np.linspace(0, 60, 120), np.arange(100)
+    )
+
+
+def test_get_waveforms(pulse_shape_library):
+    r = units.attach_units(ak.Array([[10, 30], [20]]), "mm")
+    z = units.attach_units(ak.Array([[50, 40], [10]]), "mm")
+    edep = units.attach_units(ak.Array([[100, 200], [600]]), "keV")
+
+    waveforms = waveform_from_pulse_shape_library(edep, r, z,pulse_shape_library)
+
+    assert waveforms.to_numpy().shape == (2, 100)
+    assert np.all(waveforms[0].to_numpy() == 300)
+    assert np.all(waveforms[1].to_numpy() == 600)

--- a/tests/hpge/test_waveforms.py
+++ b/tests/hpge/test_waveforms.py
@@ -108,3 +108,5 @@ def test_get_waveforms_without_phi_on_phi_library(pulse_shape_library_with_phi):
     waveforms = waveform_from_pulse_shape_library(edep, r, z, pulse_shape_library_with_phi)
 
     assert waveforms.to_numpy().shape == (1, 100)
+    # Default to first phi (0 degrees, value=1.0): 100*1 + 200*1 = 300
+    assert np.all(waveforms[0].to_numpy() == 300)

--- a/tests/hpge/test_waveforms.py
+++ b/tests/hpge/test_waveforms.py
@@ -96,12 +96,15 @@ def test_get_waveforms_with_phi(pulse_shape_library_with_phi):
 
 
 def test_get_waveforms_without_phi_on_phi_library(pulse_shape_library_with_phi):
-    """Test that calling without phi on phi-enabled library works (uses first phi)."""
+    """Test that calling without phi on phi-enabled library works.
+
+    When phi is not provided for a phi-enabled library, the function uses the first phi
+    angle in the library (index 0).
+    """
     r = units.attach_units(ak.Array([[10, 30]]), "mm")
     z = units.attach_units(ak.Array([[50, 40]]), "mm")
     edep = units.attach_units(ak.Array([[100, 200]]), "keV")
 
-    # Should work but may use arbitrary phi value
     waveforms = waveform_from_pulse_shape_library(edep, r, z, pulse_shape_library_with_phi)
 
     assert waveforms.to_numpy().shape == (1, 100)

--- a/tests/hpge/test_waveforms.py
+++ b/tests/hpge/test_waveforms.py
@@ -110,3 +110,63 @@ def test_get_waveforms_without_phi_on_phi_library(pulse_shape_library_with_phi):
     assert waveforms.to_numpy().shape == (1, 100)
     # Default to first phi (0 degrees, value=1.0): 100*1 + 200*1 = 300
     assert np.all(waveforms[0].to_numpy() == 300)
+
+
+def test_get_waveforms_mismatched_shapes(pulse_shape_library):
+    """Test that mismatched input shapes raise a ValueError."""
+    r = units.attach_units(ak.Array([[10, 30], [20]]), "mm")
+    z = units.attach_units(ak.Array([[50, 40], [10]]), "mm")
+    edep = units.attach_units(ak.Array([[100, 200, 300], [600]]), "keV")  # mismatched
+
+    with pytest.raises(ValueError, match="same number of steps"):
+        waveform_from_pulse_shape_library(edep, r, z, pulse_shape_library)
+
+
+def test_get_waveforms_mismatched_phi_shape(pulse_shape_library_with_phi):
+    """Test that mismatched phi shape raises a ValueError."""
+    r = units.attach_units(ak.Array([[10, 30]]), "mm")
+    z = units.attach_units(ak.Array([[50, 40]]), "mm")
+    edep = units.attach_units(ak.Array([[100, 200]]), "keV")
+    phi = units.attach_units(ak.Array([[0, 0, 0]]), "deg")  # mismatched
+
+    with pytest.raises(ValueError, match="same number of steps"):
+        waveform_from_pulse_shape_library(edep, r, z, pulse_shape_library_with_phi, phi)
+
+
+def test_get_waveforms_zero_energy(pulse_shape_library):
+    """Test that zero energy depositions produce a zero waveform."""
+    r = units.attach_units(ak.Array([[10, 30]]), "mm")
+    z = units.attach_units(ak.Array([[50, 40]]), "mm")
+    edep = units.attach_units(ak.Array([[0, 0]]), "keV")
+
+    waveforms = waveform_from_pulse_shape_library(edep, r, z, pulse_shape_library)
+
+    assert waveforms.to_numpy().shape == (1, 100)
+    assert np.all(waveforms[0].to_numpy() == 0)
+
+
+def test_get_waveforms_single_hit(pulse_shape_library):
+    """Test waveform extraction for a single event with a single hit."""
+    r = units.attach_units(ak.Array([[10]]), "mm")
+    z = units.attach_units(ak.Array([[50]]), "mm")
+    edep = units.attach_units(ak.Array([[500]]), "keV")
+
+    waveforms = waveform_from_pulse_shape_library(edep, r, z, pulse_shape_library)
+
+    assert waveforms.to_numpy().shape == (1, 100)
+    # Template value is 1 everywhere, so result is 500 * 1 = 500
+    assert np.all(waveforms[0].to_numpy() == 500)
+
+
+def test_get_waveforms_out_of_bounds(pulse_shape_library):
+    """Test that r/z values outside the grid are clamped to the grid boundary."""
+    # Use values far outside the grid (r_grid: 0-20 mm, z_grid: 0-60 mm)
+    r = units.attach_units(ak.Array([[100, -5]]), "mm")
+    z = units.attach_units(ak.Array([[200, -10]]), "mm")
+    edep = units.attach_units(ak.Array([[100, 200]]), "keV")
+
+    # Should not raise, and since templates are all 1, result is sum of energies
+    waveforms = waveform_from_pulse_shape_library(edep, r, z, pulse_shape_library)
+
+    assert waveforms.to_numpy().shape == (1, 100)
+    assert np.all(waveforms[0].to_numpy() == 300)  # (100 + 200) * 1


### PR DESCRIPTION
- [x] Add `waveform_from_pulse_shape_library()` function and supporting `_get_psl_waveforms_impl()` to extract full waveforms from PSL
- [x] Make the `t0` field optional in `get_hpge_pulse_shape_library()`
- [x] Add phi-angle support to waveform extraction
- [x] Fix unit consistency when t0 is absent
- [x] Fix LGDO mutation (avoid setting attrs on disk objects)
- [x] Fix phi fallback when phi is not provided for phi-enabled library
- [x] Add docs for the new functionality
- [x] Add improved test assertions (value checks for empty array case)
- [x] Add additional tests for better coverage:
  - [x] Test mismatched input shapes raise ValueError
  - [x] Test mismatched phi shape raises ValueError
  - [x] Test zero energy depositions produce zero waveform
  - [x] Test single event with single hit
  - [x] Test out-of-bounds r/z values are clamped to grid boundary