### PR TITLE
Add numba cache warmup module

### DIFF
--- a/src/reboost/hpge/psd.py
+++ b/src/reboost/hpge/psd.py
@@ -437,7 +437,7 @@ def get_current_waveform(
         time = start + dt * j
         if (time < range_t[0]) or (time > (range_t[1] - dt)):
             continue
-        y[j] = _get_waveform_value(j, edep, drift_time, template, start, dt, range_t)
+        y[j] = _get_waveform_value(j, edep, drift_time, template, start, dt)
 
     return times, y
 

--- a/src/reboost/numba_warmup_guard.py
+++ b/src/reboost/numba_warmup_guard.py
@@ -1,0 +1,151 @@
+"""Package-agnostic guard that a numba cache-warmup routine stays complete.
+
+Drop this single file into any package (its source tree or its test dir) and use
+it to make sure a *warmup* routine keeps compiling every ``@njit(cache=True)``
+function the package defines.
+
+Background
+----------
+Numba ``@njit(cache=True)`` functions compile lazily, on the first *call* with
+concrete argument types: importing a module never populates the on-disk cache.
+Packages therefore ship a *warmup* routine that calls every jitted function once
+with cheap dummy inputs, so the cache can be pre-built (e.g. baked into a
+container image). The risk is that someone adds a new jitted function and forgets
+to warm it. This module discovers every numba dispatcher in a package, runs the
+package's warmup routine, and asserts each dispatcher actually got compiled.
+
+Usage
+-----
+Write a warmup routine in your package, e.g. ``mypkg/warmup.py``::
+
+    def warmup() -> None:
+        my_kernel(np.zeros(4))
+        other_kernel(np.arange(10))
+
+    if __name__ == "__main__":
+        warmup()
+
+Then, in a test module, either write the test explicitly::
+
+    from numba_warmup_guard import assert_warmup_covers_all_jitted
+
+    def test_warmup_covers_all_jitted_functions(tmp_path):
+        assert_warmup_covers_all_jitted("mypkg", "mypkg.warmup:warmup", tmp_path)
+
+or let the factory build it for you (pytest collects the module-level name)::
+
+    from numba_warmup_guard import make_warmup_test
+
+    test_warmup = make_warmup_test("mypkg", "mypkg.warmup:warmup")
+
+Contract
+--------
+- Jitted functions are reachable as *module-level attributes* of some submodule
+  of the package (the ordinary ``@njit def foo(...)`` at top level). Dispatchers
+  hidden in closures or stashed only inside containers are not discovered.
+- The warmup entrypoint is an importable, zero-argument callable, named as a
+  ``"module:callable"`` string. Whatever it does internally is up to you.
+
+The check runs in a subprocess with a fresh numba cache directory, on purpose: a
+test suite's ``conftest`` may force ``cache=False`` (to skip caching / enable
+bounds checks), under which inner functions get folded into their callers
+without registering their own signatures. Only a clean interpreter reproduces
+the real production behaviour (``cache=True``, one cache file per function).
+
+This module imports nothing beyond the standard library; numba is imported only
+inside the subprocess it spawns.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import textwrap
+
+# Fully generic: argv[1] is the package to scan, argv[2] a "module:callable"
+# warmup entrypoint. Discover every numba dispatcher in the package, run the
+# consumer's warmup callable, then report how many dispatchers exist and which
+# were left uncompiled.
+_CHILD_SCRIPT = textwrap.dedent(
+    """
+    import importlib, pkgutil, sys
+    from numba.core.registry import CPUDispatcher
+
+    pkg_name = sys.argv[1]
+    warm_mod_name, _, warm_func_name = sys.argv[2].partition(":")
+    pkg = importlib.import_module(pkg_name)
+
+    disp = {}
+    for m in pkgutil.walk_packages(pkg.__path__, pkg.__name__ + "."):
+        if m.name == warm_mod_name:
+            continue
+        mod = importlib.import_module(m.name)
+        for o in vars(mod).values():
+            if isinstance(o, CPUDispatcher) and o.py_func.__module__.startswith(pkg_name):
+                disp[f"{o.py_func.__module__}.{o.py_func.__qualname__}"] = o
+
+    # run the consumer-provided warmup routine, however it chooses to warm
+    warm_mod = importlib.import_module(warm_mod_name)
+    getattr(warm_mod, warm_func_name)()
+
+    missing = sorted(k for k, d in disp.items() if not d.signatures)
+    print("WARMUP_TOTAL:", len(disp))
+    print("WARMUP_MISSING:", ",".join(missing))
+    """
+)
+
+
+def _run_child(package: str, warmup_entrypoint: str, tmp_path) -> dict[str, str]:
+    env = {**os.environ, "NUMBA_CACHE_DIR": str(tmp_path / "numba-cache")}
+
+    proc = subprocess.run(
+        [sys.executable, "-c", _CHILD_SCRIPT, package, warmup_entrypoint],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+    assert proc.returncode == 0, f"warmup subprocess crashed:\n{proc.stdout}\n{proc.stderr}"
+
+    # a warmup routine may emit unrelated text to stdout, so parse only our
+    # sentinel lines.
+    out = {}
+    for line in proc.stdout.splitlines():
+        for tag in ("WARMUP_TOTAL", "WARMUP_MISSING"):
+            if line.startswith(tag + ":"):
+                out[tag] = line.split(":", 1)[1].strip()
+    return out
+
+
+def assert_warmup_covers_all_jitted(package: str, warmup_entrypoint: str, tmp_path) -> None:
+    """Assert running ``warmup_entrypoint`` compiles every jitted function in ``package``.
+
+    Parameters
+    ----------
+    package
+        Import name of the package to scan for numba dispatchers, e.g. ``"mypkg"``.
+    warmup_entrypoint
+        A ``"module:callable"`` string naming a zero-argument callable that warms
+        the cache, e.g. ``"mypkg.warmup:warmup"``.
+    tmp_path
+        A pytest ``tmp_path`` (used as a throwaway numba cache directory).
+    """
+    out = _run_child(package, warmup_entrypoint, tmp_path)
+
+    assert int(out["WARMUP_TOTAL"]) > 0, f"no numba dispatchers discovered in {package}"
+
+    missing = [k for k in out["WARMUP_MISSING"].split(",") if k]
+    assert not missing, (
+        f"these numba-jitted functions were not warmed up by {warmup_entrypoint} "
+        f"(add a call for each): {missing}"
+    )
+
+
+def make_warmup_test(package: str, warmup_entrypoint: str):
+    """Build a ``test_*`` function that pytest collects; see :func:`assert_warmup_covers_all_jitted`."""
+
+    def test_warmup_covers_all_jitted_functions(tmp_path):
+        assert_warmup_covers_all_jitted(package, warmup_entrypoint, tmp_path)
+
+    return test_warmup_covers_all_jitted_functions

--- a/src/reboost/warmup.py
+++ b/src/reboost/warmup.py
@@ -1,0 +1,101 @@
+"""Warm up the on-disk numba cache.
+
+Numba ``@njit(cache=True)`` functions compile lazily, on the first *call*:
+importing a module never populates the cache. :func:`warmup` calls every jitted
+function in :mod:`reboost` once, with small dummy inputs, so the cache is
+written ahead of first real use (e.g. in a freshly built container)::
+
+    python -m reboost.warmup
+
+``tests/test_warmup.py`` fails if a new jitted function is added without a call
+here.
+"""
+
+from __future__ import annotations
+
+import awkward as ak
+import numpy as np
+
+from . import units
+from .daq import run_daq_non_sparse
+from .hpge import psd, surface
+from .optmap import convolve
+from .optmap.create import _compute_hit_maps
+from .shape import cluster
+from .spms.pe import (
+    detected_photoelectrons,
+    emitted_scintillation_photons,
+    number_of_detected_photoelectrons,
+    photoelectron_times,
+)
+
+
+def warmup() -> None:
+    """Call every cached numba-jitted function once, to populate the on-disk cache."""
+    # daq
+    run_daq_non_sparse(
+        ak.Array(
+            {
+                "evtid": [0, 1, 2],
+                "geds_energy_active": [[100.0, 50.0], [30.0], [200.0, 150.0]],
+                "geds_rawid_active": [[1000, 2000], [1000], [1000, 2000]],
+            }
+        ),
+        n_sim_events=100,
+        source_activity=1.0,
+    )
+
+    # hpge.psd + hpge.surface
+    model, x = psd.get_current_template(
+        -100, 100, 1.0, amax=1, mean_aoe=1, mu=0, sigma=10, tau=10,
+        tail_fraction=0.65, high_tail_fraction=0.1, high_tau=10,
+    )  # fmt: skip
+    edep = units.attach_units(ak.Array([[100.0, 50.0], [10.0]]), "keV")
+    drift_time = units.attach_units(ak.Array([[10.0, 20.0], [15.0]]), "ns")
+    psd.maximum_current(edep, drift_time, template=model, times=x)
+    psd.drift_time_heuristic(drift_time, edep)
+    psd.get_current_waveform(
+        np.array([100.0, 50.0]), np.array([10.0, 20.0]), model,
+        float(x[0]), 1.0, (float(x[0]), float(x[-1])),
+    )  # fmt: skip
+    charge = np.zeros(20)
+    charge[10] = 1.0
+    surface._compute_diffusion_impl(charge, nsteps=10, factor=0.29)
+
+    # shape.cluster (dist_to_surf=None and =<array> are distinct specializations)
+    trackid = ak.Array([[0, 0, 0], [1, 1]])
+    xloc = ak.Array([[0.0, 0.1, 5.0], [0.0, 0.1]])
+    yloc = ak.full_like(xloc, 0.0)
+    zloc = ak.full_like(xloc, 0.0)
+    dist = ak.Array([[1.0, 0.05, 2.0], [1.0, 0.05]])
+    cluster.cluster_by_step_length(trackid, xloc, yloc, zloc)
+    cluster.cluster_by_step_length(
+        trackid, xloc, yloc, zloc, dist, threshold_in_mm=1, threshold_surf_in_mm=1, surf_cut=0.1
+    )
+
+    # optmap + spms.pe
+    edges = np.linspace(0.0, 1.0, 5)
+    optmap = convolve.OptmapForConvolve(
+        np.array(["all"]), np.array([0]), (edges, edges, edges),
+        np.full((1, 4, 4, 4), 0.1, dtype=np.float64),
+    )  # fmt: skip
+    edep = ak.Array([[1.0, 2.0], [3.0]])
+    particle = ak.Array([[22, 22], [22]])
+    nph = ak.Array([[10, 20], [30]])
+    xloc = ak.Array([[0.1, 0.2], [0.3]])
+    yloc = ak.Array([[0.1, 0.2], [0.3]])
+    zloc = ak.Array([[0.1, 0.2], [0.3]])
+    time = ak.Array([[0.0, 1.0], [2.0]])
+    num_det_ph = emitted_scintillation_photons(edep, particle, "lar")
+    number_of_detected_photoelectrons(xloc, yloc, zloc, nph, optmap, "all")
+    number_of_detected_photoelectrons(xloc, yloc, zloc, nph, optmap, "all", max_pes_per_hit=5)
+    photoelectron_times(num_det_ph, particle, time, "lar")
+    detected_photoelectrons(nph, particle, time, xloc, yloc, zloc, optmap, "lar", "all")
+    hitcounts = np.zeros((5, 2), dtype=np.int64)
+    hitcounts[0, 0] = 1
+    hitcounts[2, 1] = 1
+    _compute_hit_maps(hitcounts, 3, np.array([0, 1], dtype=np.int64))
+
+
+if __name__ == "__main__":
+    warmup()

--- a/tests/test_warmup.py
+++ b/tests/test_warmup.py
@@ -1,0 +1,12 @@
+"""Guard test: ``reboost.warmup`` must compile every jitted function in reboost.
+
+The reusable harness lives in :mod:`reboost.numba_warmup_guard` (a drop-in,
+package-agnostic module); here we only point it at this package and its warmup
+routine.
+"""
+
+from __future__ import annotations
+
+from reboost.numba_warmup_guard import make_warmup_test
+
+test_warmup_covers_all_jitted_functions = make_warmup_test("reboost", "reboost.warmup:warmup")


### PR DESCRIPTION
## What

Adds `reboost.warmup`, a small module that pre-builds the on-disk numba cache so a freshly built container (or any first run) does not pay the full JIT compilation cost (tens of seconds) on the first real pipeline invocation.

Warming is a single command, e.g. as a build/deploy step:

```
python -m reboost.warmup
```

`reboost.warmup.warmup()` calls every `@numba.njit(cache=True)` function in `reboost` once with small dummy inputs, which is what triggers compilation and writes the cache to disk.

## Why calls, not just imports

Numba `@njit(cache=True)` without an explicit signature compiles **lazily, on the first call** with concrete argument types. Importing a module never populates the cache (confirmed against the [numba docs](https://numba.readthedocs.io/en/stable/reference/jit-compilation.html) and by the numba maintainers in [this discourse thread](https://numba.discourse.group/t/numba-warm-up-speed-with-cached-functions/1727)).

The one import-time alternative, eager compilation via explicit `@njit("sig", cache=True)`, cannot cover the heavy kernels here (`run_daq_non_sparse`, the `_iterate_stepwise_depositions_*` family, `_drift_time_heuristic_impl`, `_estimate_current_impl`): they take awkward arrays, a numba-typed `rng`, and `ComputedScintParams` NamedTuples, none of which can be spelled in a signature string. AOT (`numba.pycc`) is deprecated and has the same limitation. So calling the functions is unavoidable.

## Limitation: this is not fully production-robust

Warmup compiles exactly **one signature per function**: the type-tuple matching its dummy inputs. Numba specializes lazily per concrete argument-type tuple, so it does **not** compile all signatures a function could be called with. A production call with a different dtype, array layout (C-contiguous vs a non-contiguous slice), optional argument, or awkward structure is a *distinct* signature and will still trigger a fresh compile on first use, cache miss included, which is exactly the latency this module is meant to avoid.

So what this reliably buys you is narrow: every jitted function is reachable and compilable, and *a* cache entry exists. It does **not** guarantee the cache actually hits in production. Doing that requires the dummy inputs to match production types exactly (dtype, ndim, layout, optionality, awkward record structure), and one warmup call per distinct type-combination a function is used with. The guard test only checks "at least one signature compiled", so it cannot catch a type *mismatch*, only a function left entirely un-warmed. Treat this as a best-effort warm-up, not a guarantee of zero first-call compilation in production.

## Keeping it from rotting

The maintenance risk is that someone adds a new jitted function and forgets to warm it. The guard against this lives in `reboost.numba_warmup_guard`, a package-agnostic harness: it auto-discovers **every** `CPUDispatcher` in a package (no hand-maintained list), runs that package's warmup routine in a clean subprocess with real caching, and asserts each dispatcher got compiled. `tests/test_warmup.py` wires it to reboost in one line:

```python
test_warmup_covers_all_jitted_functions = make_warmup_test("reboost", "reboost.warmup:warmup")
```

Add a jitted function and forget to warm it, and the test fails naming the function and the file to edit, instead of the cost surfacing as a slow first run in production.

Two design choices worth noting:

- The harness runs the consumer's warmup via an explicit `"module:callable"` entrypoint, not an import side-effect, so the contract is legible and the same file drops into any package that follows the convention.
- The subprocess is deliberate: the test suite's `conftest.patch_numba_for_tests` forces `cache=False`, under which inner functions fold into their callers without registering their own signatures, so real production behaviour is only observable in a clean interpreter.

## Commits

1. **fix: drop extra argument in get_current_waveform** — a pre-existing latent bug surfaced by the warmup work: `get_current_waveform` passed a seventh argument to `_get_waveform_value` (which takes six), raising a numba `TypingError`. The function is unreachable dead code, so it went unnoticed. Isolated to the one-line fix; kept first so the guard test in the next commit (which warms this function) is valid on its own.
2. **feat: add numba cache warmup module** — the `warmup` module, the package-agnostic `numba_warmup_guard` harness, and the guard test wiring.
