### PR TITLE
feat: first implementation of optical map patching

### DIFF
--- a/docs/source/manual/optical.md
+++ b/docs/source/manual/optical.md
@@ -117,6 +117,24 @@ $ reboost-optical mergemap --settings map-settings.yaml map.map*.lh5 final-outpu
 
 :::
 
+### 3. Patch a region of the map
+
+A region of a finished map can be replaced by a separately simulated one, for
+example a volume containing a calibration source and its absorber, which the
+geometry of the base map does not contain:
+
+```console
+$ reboost-optical patchmap full-map.lh5 source-map.lh5 patched-map.lh5
+```
+
+The patch is substituted, not merged. It has to sit on the grid of the base map (matching bin widths,
+coinciding bin edges) and is copied in by index -- never resampled, as
+interpolating a ratio of counts per bin would report probabilities for volumes
+that were never simulated. Use `rebin` first if the patch was simulated with
+finer bins. The counts are what get substituted and the probabilities are
+recomputed from them, so the output is a valid map; bins that the patch never
+sampled keep the "no statistics" sentinel.
+
 ## Applying optical maps to physics simulations
 
 ### Integration into build-hit

--- a/src/reboost/optmap/cli.py
+++ b/src/reboost/optmap/cli.py
@@ -162,6 +162,16 @@ def optical_cli() -> None:
     checkmap_parser = subparsers.add_parser("checkmap", help="check optical maps")
     checkmap_parser.add_argument("input", help="input map LH5 file", metavar="INPUT_MAP")
 
+    # STEP 1e: patch a region of a map with a separately simulated one
+    patch_parser = subparsers.add_parser(
+        "patchmap", help="replace a region of an optical map with a patch map"
+    )
+    patch_parser.add_argument("input", help="input map LH5 file", metavar="INPUT_MAP")
+    patch_parser.add_argument(
+        "patch", help="patch map LH5 file, replacing the region it covers", metavar="PATCH_MAP"
+    )
+    patch_parser.add_argument("output", help="output map LH5 file", metavar="OUTPUT_MAP")
+
     # STEP X: rebin maps
     rebin_parser = subparsers.add_parser("rebin", help="rebin optical maps")
     rebin_parser.add_argument("input", help="input map LH5 files", metavar="INPUT_MAP")
@@ -237,6 +247,14 @@ def optical_cli() -> None:
 
         _check_input_file(parser, args.input)
         check_optical_map(args.input)
+
+    # STEP 1e: patch map
+    if args.command == "patchmap":
+        from .create import patch_optical_maps
+
+        _check_input_file(parser, [args.input, args.patch])
+        _check_output_file(parser, args.output)
+        patch_optical_maps(args.input, args.patch, args.output)
 
     # STEP X: rebin maps
     if args.command == "rebin":

--- a/src/reboost/optmap/create.py
+++ b/src/reboost/optmap/create.py
@@ -395,69 +395,67 @@ def check_optical_map(map_l5_file: str):
             all_binning = om.binning
 
 
+def apply_map_patch(base: OpticalMap, patch: OpticalMap) -> OpticalMap:
+    """Replace a region of an optical map with a separately simulated one.
+
+    The patch is substituted, not merged, and has to sit on the grid of the base
+    map: bin widths must match and bin edges must coincide. Only the counts are
+    used; the probabilities of the result are computed from them. Returns a new
+    map, leaving both inputs untouched.
+    """
+    assert base.binning is not None
+    assert patch.binning is not None
+
+    axis_slices = []
+    for axis, (b, pb) in enumerate(zip(base.binning, patch.binning, strict=True)):
+        be, pe = b.edges, pb.edges
+        nbins = len(pe) - 1
+        start = int(np.argmin(np.abs(be - pe[0])))
+        # bin edges are positions in metres, so compare them with an absolute
+        # tolerance: 1 nm is far looser than the ~1e-16 that float64 edges
+        # achieve, and far tighter than any real misalignment.
+        if start + nbins >= len(be) or not np.allclose(
+            be[start : start + nbins + 1], pe, rtol=0, atol=1e-9
+        ):
+            msg = (
+                f"patch map does not align with the base map on axis {axis}: "
+                "bin widths have to match and edges have to coincide"
+            )
+            raise ValueError(msg)
+        axis_slices.append(slice(start, start + nbins))
+    slices = tuple(axis_slices)
+
+    out = OpticalMap.create_empty(base.name, base.get_settings())
+    assert isinstance(out.h_vertex, np.ndarray)
+    assert isinstance(out.h_hits, np.ndarray)
+    out.h_vertex[:] = base.h_vertex
+    out.h_hits[:] = base.h_hits
+    out.h_vertex[slices] = patch.h_vertex
+    out.h_hits[slices] = patch.h_hits
+    out.create_probability()
+
+    return out
+
+
 def patch_optical_maps(
     map_l5_file: str,
     patch_l5_file: str,
     output_lh5_file: str,
 ) -> None:
-    """Replace a region of an optical map with a separately simulated one.
-
-    The patch is substituted, not merged, and has to sit on the grid of the base
-    map: bin widths must match and bin edges must coincide.
-    """
+    """Write a copy of a map with a separately simulated region substituted in."""
     submaps = list_optical_maps(map_l5_file)
     if submaps != list_optical_maps(patch_l5_file):
         msg = "available optical maps in base and patch file differ"
         raise ValueError(msg)
 
-    slices: tuple[slice, ...] | None = None
     for submap in submaps:
         log.info("patching optical map group: %s", submap)
 
-        # only the counts are needed: the probabilities are recomputed from them.
-        base_gen = lh5.read(f"/{submap}/_nr_gen", map_l5_file)
-        base_det = lh5.read(f"/{submap}/_nr_det", map_l5_file)
-        patch_gen = lh5.read(f"/{submap}/_nr_gen", patch_l5_file)
-        patch_det = lh5.read(f"/{submap}/_nr_det", patch_l5_file)
-        for h in (base_gen, base_det, patch_gen, patch_det):
-            if not isinstance(h, Histogram):
-                msg = f"encountered invalid optical map while reading group {submap}"
-                raise RuntimeError(msg)  # noqa: TRY004 (keep it in line with the other exceptions)
-
-        if slices is None:
-            axis_slices = []
-            for axis, (b, pb) in enumerate(zip(base_gen.binning, patch_gen.binning, strict=True)):
-                be, pe = b.edges, pb.edges
-                nbins = len(pe) - 1
-                start = int(np.argmin(np.abs(be - pe[0])))
-                # bin edges are positions in metres, so compare them with an absolute
-                # tolerance: 1 nm is far looser than the ~1e-16 that float64 edges
-                # achieve, and far tighter than any real misalignment.
-                if start + nbins >= len(be) or not np.allclose(
-                    be[start : start + nbins + 1], pe, rtol=0, atol=1e-9
-                ):
-                    msg = (
-                        f"patch map does not align with the base map on axis {axis}: "
-                        "bin widths have to match and edges have to coincide"
-                    )
-                    raise ValueError(msg)
-                axis_slices.append(slice(start, start + nbins))
-            slices = tuple(axis_slices)
-            log.info("patch occupies base bins %s", [(s.start, s.stop) for s in slices])
-
-            probe = OpticalMap(submap, None)
-            probe.binning = base_gen.binning
-            settings = probe.get_settings()
-
-        om = OpticalMap.create_empty(submap, settings)
-        om.h_vertex = base_gen.weights.nda
-        om.h_hits = base_det.weights.nda
-        assert isinstance(om.h_vertex, np.ndarray)
-        assert isinstance(om.h_hits, np.ndarray)
-        om.h_vertex[slices] = patch_gen.weights.nda
-        om.h_hits[slices] = patch_det.weights.nda
-        om.create_probability()
-        om.write_lh5(lh5_file=output_lh5_file, group=submap, wo_mode="write_safe")
+        patched = apply_map_patch(
+            OpticalMap.load_from_file(map_l5_file, submap),
+            OpticalMap.load_from_file(patch_l5_file, submap),
+        )
+        patched.write_lh5(lh5_file=output_lh5_file, group=submap, wo_mode="write_safe")
 
 
 def rebin_optical_maps(map_l5_file: str, output_lh5_file: str, factor: int):

--- a/src/reboost/optmap/create.py
+++ b/src/reboost/optmap/create.py
@@ -395,6 +395,71 @@ def check_optical_map(map_l5_file: str):
             all_binning = om.binning
 
 
+def patch_optical_maps(
+    map_l5_file: str,
+    patch_l5_file: str,
+    output_lh5_file: str,
+) -> None:
+    """Replace a region of an optical map with a separately simulated one.
+
+    The patch is substituted, not merged, and has to sit on the grid of the base
+    map: bin widths must match and bin edges must coincide.
+    """
+    submaps = list_optical_maps(map_l5_file)
+    if submaps != list_optical_maps(patch_l5_file):
+        msg = "available optical maps in base and patch file differ"
+        raise ValueError(msg)
+
+    slices: tuple[slice, ...] | None = None
+    for submap in submaps:
+        log.info("patching optical map group: %s", submap)
+
+        # only the counts are needed: the probabilities are recomputed from them.
+        base_gen = lh5.read(f"/{submap}/_nr_gen", map_l5_file)
+        base_det = lh5.read(f"/{submap}/_nr_det", map_l5_file)
+        patch_gen = lh5.read(f"/{submap}/_nr_gen", patch_l5_file)
+        patch_det = lh5.read(f"/{submap}/_nr_det", patch_l5_file)
+        for h in (base_gen, base_det, patch_gen, patch_det):
+            if not isinstance(h, Histogram):
+                msg = f"encountered invalid optical map while reading group {submap}"
+                raise RuntimeError(msg)  # noqa: TRY004 (keep it in line with the other exceptions)
+
+        if slices is None:
+            axis_slices = []
+            for axis, (b, pb) in enumerate(zip(base_gen.binning, patch_gen.binning, strict=True)):
+                be, pe = b.edges, pb.edges
+                nbins = len(pe) - 1
+                start = int(np.argmin(np.abs(be - pe[0])))
+                # bin edges are positions in metres, so compare them with an absolute
+                # tolerance: 1 nm is far looser than the ~1e-16 that float64 edges
+                # achieve, and far tighter than any real misalignment.
+                if start + nbins >= len(be) or not np.allclose(
+                    be[start : start + nbins + 1], pe, rtol=0, atol=1e-9
+                ):
+                    msg = (
+                        f"patch map does not align with the base map on axis {axis}: "
+                        "bin widths have to match and edges have to coincide"
+                    )
+                    raise ValueError(msg)
+                axis_slices.append(slice(start, start + nbins))
+            slices = tuple(axis_slices)
+            log.info("patch occupies base bins %s", [(s.start, s.stop) for s in slices])
+
+            probe = OpticalMap(submap, None)
+            probe.binning = base_gen.binning
+            settings = probe.get_settings()
+
+        om = OpticalMap.create_empty(submap, settings)
+        om.h_vertex = base_gen.weights.nda
+        om.h_hits = base_det.weights.nda
+        assert isinstance(om.h_vertex, np.ndarray)
+        assert isinstance(om.h_hits, np.ndarray)
+        om.h_vertex[slices] = patch_gen.weights.nda
+        om.h_hits[slices] = patch_det.weights.nda
+        om.create_probability()
+        om.write_lh5(lh5_file=output_lh5_file, group=submap, wo_mode="write_safe")
+
+
 def rebin_optical_maps(map_l5_file: str, output_lh5_file: str, factor: int):
     """Rebin the optical map by an integral factor.
 

--- a/tests/test_optmap.py
+++ b/tests/test_optmap.py
@@ -12,6 +12,7 @@ from reboost.optmap.create import (
     create_optical_maps,
     list_optical_maps,
     merge_optical_maps,
+    patch_optical_maps,
     rebin_optical_maps,
 )
 from reboost.optmap.optmap import OpticalMap
@@ -249,3 +250,65 @@ def test_optmap_save_and_load(tmptestdir, tbl_hits):
     assert isinstance(om, OpticalMap)
 
     check_optical_map(map_fn)
+
+
+def _write_count_map(fn, rng, bins, nr_gen, nr_det, group="all"):
+    """Write a single-group optical map with uniform counts."""
+    om = OpticalMap.create_empty(group, {"range_in_m": rng, "bins": bins})
+    om.h_vertex[:] = nr_gen
+    om.h_hits[:] = nr_det
+    om.create_probability()
+    om.write_lh5(lh5_file=str(fn), group=group, wo_mode="overwrite_file")
+    return str(fn)
+
+
+def test_optmap_patch(tmptestdir):
+    base = _write_count_map(tmptestdir / "patch-base.lh5", [[0, 1]] * 3, [10] * 3, 100, 50)
+    # 0.2..0.5 lands exactly on the base grid: bins 2..5 on every axis
+    patch = _write_count_map(tmptestdir / "patch-src.lh5", [[0.2, 0.5]] * 3, [3] * 3, 200, 50)
+
+    out = str(tmptestdir / "patch-out.lh5")
+    patch_optical_maps(base, patch, out)
+
+    nr_gen = lh5.read("/all/_nr_gen", out).weights.nda
+    prob = lh5.read("/all/prob", out).weights.nda
+    region = (slice(2, 5),) * 3
+
+    # counts substituted, not added (a merge would give 300)
+    assert np.all(nr_gen[region] == 200)
+    # probability recomputed from the patched counts
+    assert np.allclose(prob[region], 0.25)
+
+    outside = np.ones_like(prob, dtype=bool)
+    outside[region] = False
+    assert np.all(nr_gen[outside] == 100)
+    assert np.allclose(prob[outside], 0.5)
+
+
+def test_optmap_patch_rejects_misaligned(tmptestdir):
+    base = _write_count_map(tmptestdir / "rej-base.lh5", [[0, 1]] * 3, [10] * 3, 100, 50)
+    # edges at 0.25 do not coincide with the base grid
+    bad = _write_count_map(tmptestdir / "rej-patch.lh5", [[0.25, 0.55]] * 3, [3] * 3, 100, 50)
+
+    with pytest.raises(ValueError, match="does not align"):
+        patch_optical_maps(base, bad, str(tmptestdir / "rej-out.lh5"))
+
+
+def test_optmap_patch_keeps_no_stats_sentinel(tmptestdir):
+    base = _write_count_map(tmptestdir / "sent-base.lh5", [[0, 1]] * 3, [10] * 3, 100, 50)
+
+    om = OpticalMap.create_empty("all", {"range_in_m": [[0.2, 0.5]] * 3, "bins": [3] * 3})
+    om.h_vertex[:] = 100
+    om.h_vertex[0, 0, 0] = 0  # a bin the patch never sampled
+    om.h_hits[:] = 50
+    om.h_hits[0, 0, 0] = 0
+    om.create_probability()
+    patch = str(tmptestdir / "sent-patch.lh5")
+    om.write_lh5(lh5_file=patch, group="all", wo_mode="overwrite_file")
+
+    out = str(tmptestdir / "sent-out.lh5")
+    patch_optical_maps(base, patch, out)
+
+    prob = lh5.read("/all/prob", out).weights.nda
+    assert prob[2, 2, 2] == -1  # sentinel kept, base value not reinstated
+    assert np.allclose(prob[3, 3, 3], 0.5)

--- a/tests/test_optmap.py
+++ b/tests/test_optmap.py
@@ -8,6 +8,7 @@ import pytest
 from lgdo import Array, Table
 
 from reboost.optmap.create import (
+    apply_map_patch,
     check_optical_map,
     create_optical_maps,
     list_optical_maps,
@@ -285,30 +286,44 @@ def test_optmap_patch(tmptestdir):
     assert np.allclose(prob[outside], 0.5)
 
 
-def test_optmap_patch_rejects_misaligned(tmptestdir):
-    base = _write_count_map(tmptestdir / "rej-base.lh5", [[0, 1]] * 3, [10] * 3, 100, 50)
+def _count_map(rng, bins, nr_gen, nr_det, group="all"):
+    """An in-memory map carrying only counts."""
+    om = OpticalMap.create_empty(group, {"range_in_m": rng, "bins": bins})
+    om.h_vertex[:] = nr_gen
+    om.h_hits[:] = nr_det
+    return om
+
+
+def test_apply_map_patch():
+    """Counts are substituted, probabilities recomputed, inputs left alone."""
+    base = _count_map([[0, 1]] * 3, [10] * 3, 100, 50)
+    patch = _count_map([[0.2, 0.5]] * 3, [3] * 3, 200, 50)
+    # a bin the patch never sampled keeps the "no statistics" sentinel
+    patch.h_vertex[0, 0, 0] = 0
+    patch.h_hits[0, 0, 0] = 0
+
+    out = apply_map_patch(base, patch)
+    region = (slice(2, 5),) * 3
+
+    # substituted, not added (a merge would give 300)
+    assert np.all(out.h_vertex[3:5, 3:5, 3:5] == 200)
+    assert np.allclose(out.h_prob[3:5, 3:5, 3:5], 0.25)
+    # the unsampled bin keeps the "no statistics" sentinel
+    assert out.h_vertex[2, 2, 2] == 0
+    assert out.h_prob[2, 2, 2] == -1
+
+    outside = np.ones_like(out.h_vertex, dtype=bool)
+    outside[region] = False
+    assert np.all(out.h_vertex[outside] == 100)
+    assert np.allclose(out.h_prob[outside], 0.5)
+
+    assert np.all(base.h_vertex == 100)
+
+
+def test_apply_map_patch_rejects_misaligned():
+    base = _count_map([[0, 1]] * 3, [10] * 3, 100, 50)
     # edges at 0.25 do not coincide with the base grid
-    bad = _write_count_map(tmptestdir / "rej-patch.lh5", [[0.25, 0.55]] * 3, [3] * 3, 100, 50)
+    bad = _count_map([[0.25, 0.55]] * 3, [3] * 3, 100, 50)
 
     with pytest.raises(ValueError, match="does not align"):
-        patch_optical_maps(base, bad, str(tmptestdir / "rej-out.lh5"))
-
-
-def test_optmap_patch_keeps_no_stats_sentinel(tmptestdir):
-    base = _write_count_map(tmptestdir / "sent-base.lh5", [[0, 1]] * 3, [10] * 3, 100, 50)
-
-    om = OpticalMap.create_empty("all", {"range_in_m": [[0.2, 0.5]] * 3, "bins": [3] * 3})
-    om.h_vertex[:] = 100
-    om.h_vertex[0, 0, 0] = 0  # a bin the patch never sampled
-    om.h_hits[:] = 50
-    om.h_hits[0, 0, 0] = 0
-    om.create_probability()
-    patch = str(tmptestdir / "sent-patch.lh5")
-    om.write_lh5(lh5_file=patch, group="all", wo_mode="overwrite_file")
-
-    out = str(tmptestdir / "sent-out.lh5")
-    patch_optical_maps(base, patch, out)
-
-    prob = lh5.read("/all/prob", out).weights.nda
-    assert prob[2, 2, 2] == -1  # sentinel kept, base value not reinstated
-    assert np.allclose(prob[3, 3, 3], 0.5)
+        apply_map_patch(base, bad)


### PR DESCRIPTION
**Motivation (see issue https://github.com/legend-exp/legend-simflow/issues/321):** 
The standard LEGEND-200 map is simulated without the source or its tantalum absorber, so its detection probabilities near the source are wrong by several percent. Re-simulating a small volume around the source at the same binning and substituting it fixes that region without re-running the full map.

**Additions:**
Adds `reboost-optical patchmap`, which replaces a region of a finished optical map with a separately simulated one:
`reboost-optical patchmap full-map.lh5 source-map.lh5 patched-map.lh5`

**Requirements for the patch map:**
- same bin width as the full map: The bin width is a property of an axis of the 3D map array, not a region. The patched map has to be rebinned onto the base grid first, if needed.
- patch edges land on base edges
- patch map fits inside the base map
- check the patch map first! "no-statistics" (`-1`) bins are copied over as-is. Those bins usually sit inside a solid material where a detection probability is genuinely undefined. Use `OpticalMap.check_histograms()` to check the statistics of your patched map first!

In the plot attached you can see the patch because it has slightly more stats. The source and absorber are not visible in the slice view.

_Parts of this contribution were drafted with AI assistance and reviewed before submission._

<img width="560" height="933" alt="image" src="https://github.com/user-attachments/assets/a79adcc0-a0c5-40d6-9cb6-d077fa1c3d65" />
